### PR TITLE
Ajout de definition et de parser

### DIFF
--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -34,22 +34,18 @@ function parseBoolean(value) {
 }
 
 function parseDate(value) {
-  const dateRegex = /^\d{4}-\d{2}-\d{2}$/
-  const dateTimeRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?: [+-]\d{2}:?\d{2})?$/
+  const simpleDateRegex = /^\d{4}-\d{2}-\d{2}$/
+  const customDateTimeRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{2}$/
 
-  if (dateRegex.test(value)) {
+  if (simpleDateRegex.test(value)) {
     return value
   }
 
-  if (dateTimeRegex.test(value)) {
-    return new Date(value).toISOString()
+  if (customDateTimeRegex.test(value)) {
+    return (new Date(value)).toISOString()
   }
 
-  if (value === '') {
-    return undefined
-  }
-
-  throw new Error(`Data invalide : ${value}`)
+  console.warn(`Unknown date format: ${value || 'VIDE'}`)
 }
 
 async function readDataFromCsvFile(filePath, tableDefinition) {

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -101,7 +101,7 @@ const POINTS_PRELEVEMENT_DEFINITION = {
     type_milieu: {parse: value => typesMilieu[value] || null},
     profondeur: {parse: parseNumber},
     zre: {parse: parseBoolean},
-    reservoir_biologique: {parse: parseString},
+    reservoir_biologique: {parse: parseBoolean},
     insee_com: {parse: parseString},
     code_bdlisa: {parse: parseString},
     code_meso: {parse: parseString},

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -94,7 +94,7 @@ const POINTS_PRELEVEMENT_DEFINITION = {
   schema: {
     id_point: {parse: parseString},
     nom: {parse: parseString},
-    autres_noms: {drop: true},
+    autres_noms: {parse: parseString},
     code_bnpe: {parse: parseString},
     id_bss: {parse: parseString},
     code_aiot: {parse: parseString},

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -218,8 +218,8 @@ const RESULTATS_DEFINITION = {
   requiredFields: ['id_resultat']
 }
 
-async function loadDocuments() {
-  const csvContent = await fs.readFile('data/document.csv', 'utf8')
+async function loadExploitationsRegles() {
+  const csvContent = await fs.readFile('data/exploitation-regle.csv', 'utf8')
   const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
 
   return rows
@@ -227,13 +227,6 @@ async function loadDocuments() {
 
 async function loadExploitationsModalitesSuivis() {
   const csvContent = await fs.readFile('data/exploitation-modalite-suivi.csv', 'utf8')
-  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
-
-  return rows
-}
-
-async function loadModalitesSuivis() {
-  const csvContent = await fs.readFile('data/modalite-suivi.csv', 'utf8')
   const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
 
   return rows
@@ -253,36 +246,47 @@ async function loadExploitationsSerie() {
   return rows
 }
 
-async function loadSerieDonnees() {
-  const csvContent = await fs.readFile('data/serie-donnees.csv', 'utf8')
-  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
-
-  return rows
-}
-
-async function loadResultatsSuivi() {
-  const csvContent = await fs.readFile('data/resultat-suivi.csv', 'utf8')
-  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
-
-  return rows
-}
-
 // Initialisation
-export const beneficiaires = await loadBeneficiaires()
-export const exploitations = await loadExploitations()
+export const beneficiaires = await readDataFromCsvFile(
+  'data/beneficiaire.csv',
+  BENEFICIAIRES_DEFINITION
+)
+export const exploitations = await readDataFromCsvFile(
+  'data/exploitation.csv',
+  EXPLOITATIONS_DEFINITION
+)
 export const pointsPrelevement = await readDataFromCsvFile(
   'data/point-prelevement.csv',
   POINTS_PRELEVEMENT_DEFINITION
 )
-export const regles = await loadRegles()
+export const regles = await readDataFromCsvFile(
+  'data/regle.csv',
+  REGLES_DEFINITION
+)
+export const documents = await readDataFromCsvFile(
+  'data/document.csv',
+  DOCUMENTS_DEFINITION
+)
+
+export const modalitesSuivis = await readDataFromCsvFile(
+  'data/modalite-suivi.csv',
+  MODALITES_DEFINITION
+)
+
+export const serieDonnees = await readDataFromCsvFile(
+  'data/serie-donnees.csv',
+  SERIES_DEFINITION
+)
+
+export const resultatsSuivi = await readDataFromCsvFile(
+  'data/resultat-suivi.csv',
+  RESULTATS_DEFINITION
+)
+
 export const exploitationsRegles = await loadExploitationsRegles()
-export const documents = await loadDocuments()
 export const exploitationModalites = await loadExploitationsModalitesSuivis()
-export const modalitesSuivis = await loadModalitesSuivis()
 export const exploitationsUsage = await loadExploitationsUsage()
 export const exploitationsSerie = await loadExploitationsSerie()
-export const serieDonnees = await loadSerieDonnees()
-export const resultatsSuivi = await loadResultatsSuivi()
 
 export const indexedExploitations = keyBy(exploitations, 'id_exploitation')
 export const indexedPointsPrelevement = keyBy(pointsPrelevement, 'id_point')

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -17,6 +17,41 @@ function parseNumber(value) {
   return value === '' ? undefined : Number(value)
 }
 
+function parseBoolean(value) {
+  switch (value.toLowerCase()) {
+    case 't': {
+      return true
+    }
+
+    case 'f': {
+      return false
+    }
+
+    default: {
+      return undefined
+    }
+  }
+}
+
+function parseDate(value) {
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/
+  const dateTimeRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?: [+-]\d{2}:?\d{2})?$/
+
+  if (dateRegex.test(value)) {
+    return value
+  }
+
+  if (dateTimeRegex.test(value)) {
+    return new Date(value).toISOString()
+  }
+
+  if (value === '') {
+    return undefined
+  }
+
+  throw new Error(`Data invalide : ${value}`)
+}
+
 async function readDataFromCsvFile(filePath, tableDefinition) {
   const csvContent = await fs.readFile(filePath, 'utf8')
   const {data: inputRows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -92,7 +92,7 @@ const POINTS_PRELEVEMENT_DEFINITION = {
     code_aiot: {parse: parseString},
     type_milieu: {parse: value => typesMilieu[value] || null},
     profondeur: {parse: parseNumber},
-    zre: {parse: parseString},
+    zre: {parse: parseBoolean},
     reservoir_biologique: {parse: parseString},
     insee_com: {parse: parseString},
     code_bdlisa: {parse: parseString},

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -4,7 +4,7 @@ import {keyBy} from 'lodash-es'
 import Papa from 'papaparse'
 
 import {extractGeometry} from '../../util/extract-geom.js'
-import {typesMilieu} from '../../nomenclature.js'
+import {typesMilieu, statutsExploitation, parametres, unites, contraintes, natures, frequences, traitements} from '../../nomenclature.js'
 
 /* Parsers */
 

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -52,6 +52,14 @@ function parseDate(value) {
   console.warn(`Unknown date format: ${value || 'VIDE'}`)
 }
 
+function parseNomenclature(value, nomenclature) {
+  if (!nomenclature[value] || value === '') {
+    console.warn(`Valeur inconnue dans la nomenclature: ${value || 'VIDE'}`)
+  }
+
+  return nomenclature[value]
+}
+
 async function readDataFromCsvFile(filePath, tableDefinition) {
   const csvContent = await fs.readFile(filePath, 'utf8')
   const {data: inputRows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
@@ -144,10 +152,10 @@ const BENEFICIAIRES_DEFINITION = {
 const REGLES_DEFINITION = {
   schema: {
     id_regle: {parse: parseString},
-    parametre: {parse: value => parametres[value] || null},
-    unite: {parse: value => unites[value] || null},
+    parametre: {parse: value => parseNomenclature(value, parametres)},
+    unite: {parse: value => parseNomenclature(value, unites)},
     valeur: {parse: parseNumber},
-    contrainte: {parse: value => contraintes[value] || null},
+    contrainte: {parse: value => parseNomenclature(value, contraintes)},
     debut_validite: {parse: parseDate},
     fin_validite: {parse: parseDate},
     debut_periode: {parse: parseDate},
@@ -163,7 +171,7 @@ const DOCUMENTS_DEFINITION = {
     id_document: {parse: parseString},
     nom_fichier: {parse: parseString},
     reference: {parse: parseString},
-    nature: {parse: value => natures[value] || null},
+    nature: {parse: value => parseNomenclature(value, natures)},
     date_signature: {parse: parseDate},
     date_fin_validite: {parse: parseDate},
     date_ajout: {parse: parseDate},
@@ -175,16 +183,16 @@ const DOCUMENTS_DEFINITION = {
 const MODALITES_DEFINITION = {
   schema: {
     id_modalite: {parse: parseString},
-    freq_volume_preleve: {parse: value => frequences[value] || null},
-    freq_debit_preleve: {parse: value => frequences[value] || null},
-    freq_debit_reserve: {parse: value => frequences[value] || null},
-    freq_conductivite: {parse: value => frequences[value] || null},
-    freq_temperature: {parse: value => frequences[value] || null},
-    freq_niveau_eau: {parse: value => frequences[value] || null},
-    freq_ph: {parse: value => frequences[value] || null},
-    freq_chlorure: {parse: value => frequences[value] || null},
-    freq_nitrates: {parse: value => frequences[value] || null},
-    freq_sulfates: {parse: value => frequences[value] || null},
+    freq_volume_preleve: {parse: value => parseNomenclature(value, frequences)},
+    freq_debit_preleve: {parse: value => parseNomenclature(value, frequences)},
+    freq_debit_reserve: {parse: value => parseNomenclature(value, frequences)},
+    freq_conductivite: {parse: value => parseNomenclature(value, frequences)},
+    freq_temperature: {parse: value => parseNomenclature(value, frequences)},
+    freq_niveau_eau: {parse: value => parseNomenclature(value, frequences)},
+    freq_ph: {parse: value => parseNomenclature(value, frequences)},
+    freq_chlorure: {parse: value => parseNomenclature(value, frequences)},
+    freq_nitrates: {parse: value => parseNomenclature(value, frequences)},
+    freq_sulfates: {parse: value => parseNomenclature(value, frequences)},
     remarque: {parse: parseString}
   },
   requiredFields: ['id_modalite']
@@ -195,11 +203,11 @@ const SERIES_DEFINITION = {
     id_serie: {parse: parseString},
     detail_point_suivi: {parse: parseString},
     profondeur: {parse: parseNumber},
-    parametre: {parse: value => parametres[value] || null},
-    unite: {parse: value => unites[value] || null},
-    frequence_acquisition: {parse: value => frequences[value] || null},
-    traitement: {parse: value => traitements[value] || null},
-    frequence_traitement: {parse: value => frequences[value] || null},
+    parametre: {parse: value => parseNomenclature(value, parametres)},
+    unite: {parse: value => parseNomenclature(value, unites)},
+    frequence_acquisition: {parse: value => parseNomenclature(value, frequences)},
+    traitement: {parse: value => parseNomenclature(value, traitements)},
+    frequence_traitement: {parse: value => parseNomenclature(value, frequences)},
     etat_prelevement: {parse: parseBoolean},
     debut_periode: {parse: parseDate},
     fin_periode: {parse: parseDate},

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -104,32 +104,118 @@ const POINTS_PRELEVEMENT_DEFINITION = {
   requiredFields: ['id_point', 'nom', 'geom']
 }
 
-async function loadExploitations() {
-  const csvContent = await fs.readFile('data/exploitation.csv', 'utf8')
-  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
-
-  return rows
+const EXPLOITATIONS_DEFINITION = {
+  schema: {
+    id_exploitation: {parse: parseString},
+    date_debut: {parse: parseDate},
+    date_fin: {parse: parseDate},
+    statut: {parse: value => statutsExploitation[value] || null},
+    raison_abandon: {parse: parseString},
+    remarque: {parse: parseString},
+    id_point: {parse: parseString},
+    id_beneficiaire: {parse: parseString}
+  },
+  requiredFields: ['id_exploitation', 'id_point']
 }
 
-async function loadBeneficiaires() {
-  const csvContent = await fs.readFile('data/beneficiaire.csv', 'utf8')
-  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
-
-  return rows
+const BENEFICIAIRES_DEFINITION = {
+  schema: {
+    id_beneficiaire: {parse: parseString},
+    raison_sociale: {parse: parseString},
+    sigle: {parse: parseString},
+    civilite: {parse: parseString},
+    nom: {parse: parseString},
+    prenom: {parse: parseString},
+    email: {parse: parseString},
+    adresse_1: {parse: parseString},
+    adresse_2: {parse: parseString},
+    bp: {parse: parseString},
+    code_postal: {parse: parseString},
+    commune: {parse: parseString},
+    numero_telephone: {parse: parseString}
+  },
+  requiredFields: ['id_beneficiaire']
 }
 
-async function loadRegles() {
-  const csvContent = await fs.readFile('data/regle.csv', 'utf8')
-  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
-
-  return rows
+const REGLES_DEFINITION = {
+  schema: {
+    id_regle: {parse: parseString},
+    parametre: {parse: value => parametres[value] || null},
+    unite: {parse: value => unites[value] || null},
+    valeur: {parse: parseNumber},
+    contrainte: {parse: value => contraintes[value] || null},
+    debut_validite: {parse: parseDate},
+    fin_validite: {parse: parseDate},
+    debut_periode: {parse: parseDate},
+    fin_periode: {parse: parseDate},
+    remarque: {parse: parseString},
+    id_document: {parse: parseString}
+  },
+  requiredFields: ['id_regle']
 }
 
-async function loadExploitationsRegles() {
-  const csvContent = await fs.readFile('data/exploitation-regle.csv', 'utf8')
-  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
+const DOCUMENTS_DEFINITION = {
+  schema: {
+    id_document: {parse: parseString},
+    nom_fichier: {parse: parseString},
+    reference: {parse: parseString},
+    nature: {parse: value => natures[value] || null},
+    date_signature: {parse: parseDate},
+    date_fin_validite: {parse: parseDate},
+    date_ajout: {parse: parseDate},
+    remarque: {parse: parseString}
+  },
+  requiredFields: ['id_document']
+}
 
-  return rows
+const MODALITES_DEFINITION = {
+  schema: {
+    id_modalite: {parse: parseString},
+    freq_volume_preleve: {parse: value => frequences[value] || null},
+    freq_debit_preleve: {parse: value => frequences[value] || null},
+    freq_debit_reserve: {parse: value => frequences[value] || null},
+    freq_conductivite: {parse: value => frequences[value] || null},
+    freq_temperature: {parse: value => frequences[value] || null},
+    freq_niveau_eau: {parse: value => frequences[value] || null},
+    freq_ph: {parse: value => frequences[value] || null},
+    freq_chlorure: {parse: value => frequences[value] || null},
+    freq_nitrates: {parse: value => frequences[value] || null},
+    freq_sulfates: {parse: value => frequences[value] || null},
+    remarque: {parse: parseString}
+  },
+  requiredFields: ['id_modalite']
+}
+
+const SERIES_DEFINITION = {
+  schema: {
+    id_serie: {parse: parseString},
+    detail_point_suivi: {parse: parseString},
+    profondeur: {parse: parseNumber},
+    parametre: {parse: value => parametres[value] || null},
+    unite: {parse: value => unites[value] || null},
+    frequence_acquisition: {parse: value => frequences[value] || null},
+    traitement: {parse: value => traitements[value] || null},
+    frequence_traitement: {parse: value => frequences[value] || null},
+    etat_prelevement: {parse: parseBoolean},
+    debut_periode: {parse: parseDate},
+    fin_periode: {parse: parseDate},
+    remarque: {parse: parseString},
+    id_declaration: {parse: parseString},
+    id_fichier: {parse: parseString}
+  },
+  requiredFields: ['id_serie']
+}
+
+const RESULTATS_DEFINITION = {
+  schema: {
+    id_resultat: {parse: parseString},
+    id_origine: {parse: parseString},
+    date_heure_mesure: {parse: parseDate},
+    valeur: {parse: parseNumber},
+    remarque: {parse: parseString},
+    id_serie: {parse: parseString}
+  },
+  requiredFields: ['id_resultat']
 }
 
 async function loadDocuments() {

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -27,8 +27,12 @@ function parseBoolean(value) {
       return false
     }
 
-    default: {
+    case '': {
       return undefined
+    }
+
+    default: {
+      console.warn('Valeur booléenne inconnue', value)
     }
   }
 }

--- a/lib/nomenclature.js
+++ b/lib/nomenclature.js
@@ -15,3 +15,74 @@ export const typesMilieu = {
   2: 'Eau souterraine',
   3: 'Eau de transition'
 }
+
+export const statutsExploitation = {
+  1: 'En activité',
+  2: 'Terminée',
+  3: 'Abandonnée',
+  4: null
+}
+
+export const unites = {
+  1: 'm3',
+  2: 'L/s',
+  3: 'm3/h',
+  4: 'mg/L',
+  5: 'degré Celsius',
+  6: 'm NGR',
+  7: 'µS/cm'
+}
+
+export const contraintes = {
+  1: 'minimum',
+  2: 'maximum',
+  3: 'moyenne'
+}
+
+export const parametres = {
+  1: 'Volume journalier',
+  2: 'Volume mensuel',
+  3: 'Volume annuel',
+  4: 'Relevé d’index',
+  5: 'Débit prélevé',
+  6: 'Débit réservé',
+  7: 'Chlorure',
+  8: 'Nitrates',
+  9: 'Sulfates',
+  10: 'Température',
+  11: 'Niveau piézométrique',
+  12: 'Conductivité électrique',
+  13: 'pH'
+}
+
+export const natures = {
+  1: 'Autorisation AOT',
+  2: 'Autorisation CSP',
+  3: 'Autorisation CSP - IOTA',
+  4: 'Autorisation hydroélectricité',
+  5: 'Autorisation ICPE',
+  6: 'Autorisation IOTA',
+  7: 'Délibération abandon',
+  8: 'Rapport hydrogéologue agréé'
+}
+
+export const frequences = {
+  1: 'seconde',
+  2: 'minute',
+  3: '15 minutes',
+  4: 'heure',
+  5: 'jour',
+  6: 'semaine',
+  7: 'mois',
+  8: 'trimestre',
+  9: 'année',
+  10: 'autre',
+  11: null
+}
+
+export const traitements = {
+  1: 'minimum',
+  2: 'maximum',
+  3: 'moyenne',
+  4: 'différence d’index'
+}

--- a/lib/nomenclature.js
+++ b/lib/nomenclature.js
@@ -19,8 +19,7 @@ export const typesMilieu = {
 export const statutsExploitation = {
   1: 'En activité',
   2: 'Terminée',
-  3: 'Abandonnée',
-  4: null
+  3: 'Abandonnée'
 }
 
 export const unites = {
@@ -76,8 +75,7 @@ export const frequences = {
   7: 'mois',
   8: 'trimestre',
   9: 'année',
-  10: 'autre',
-  11: null
+  10: 'autre'
 }
 
 export const traitements = {


### PR DESCRIPTION
Cette PR ajoute des parsers et des définitions afin de simplifier la gestion des données : 
- Mise à jour de la nomenclature pour les propriétés utilisant des identifiants
- Ajout des parsers pour les booléens et les dates
- Ajout des définitions pour les objets "exploitations", "beneficiaires", "regles", "documents", "modalites", "series" et "resultats"
