### PR TITLE
Mise à jour des routes

### DIFF
--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -264,6 +264,20 @@ async function loadExploitationsDocuments() {
   return rows
 }
 
+async function loadBss() {
+  const csvContent = await fs.readFile('data/bss.csv', 'utf8')
+  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
+
+  return rows
+}
+
+async function loadBnpe() {
+  const csvContent = await fs.readFile('data/point-prelevement-bnpe.csv', 'utf8')
+  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
+
+  return rows
+}
+
 // Initialisation
 export const beneficiaires = await readDataFromCsvFile(
   'data/beneficiaire.csv',
@@ -306,6 +320,8 @@ export const exploitationsDocuments = await loadExploitationsDocuments()
 export const exploitationModalites = await loadExploitationsModalitesSuivis()
 export const exploitationsUsage = await loadExploitationsUsage()
 export const exploitationsSerie = await loadExploitationsSerie()
+export const bss = await loadBss()
+export const bnpe = await loadBnpe()
 
 export const indexedExploitations = keyBy(exploitations, 'id_exploitation')
 export const indexedPointsPrelevement = keyBy(pointsPrelevement, 'id_point')
@@ -314,3 +330,5 @@ export const indexedRegles = keyBy(regles, 'id_regle')
 export const indexedDocuments = keyBy(documents, 'id_document')
 export const indexedModalitesSuivis = keyBy(modalitesSuivis, 'id_modalite')
 export const indexedSeriesDonnees = keyBy(serieDonnees, 'id_serie')
+export const indexedBss = keyBy(bss, 'id_bss')
+export const indexedBnpeByPointPrelevement = keyBy(bnpe, 'code_point_prelevement')

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -229,6 +229,22 @@ const RESULTATS_DEFINITION = {
   requiredFields: ['id_resultat']
 }
 
+const BSS_DEFINITION = {
+  schema: {
+    id_bss: {parse: parseString},
+    lien_infoterre: {parse: parseString}
+  },
+  requiredFields: ['id_bss']
+}
+
+const BNPE_DEFINITION = {
+  schema: {
+    code_point_prelevement: {parse: parseString},
+    url_ouvrage: {parse: parseString}
+  },
+  requiredFields: ['code_point_prelevement']
+}
+
 async function loadExploitationsRegles() {
   const csvContent = await fs.readFile('data/exploitation-regle.csv', 'utf8')
   const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
@@ -259,20 +275,6 @@ async function loadExploitationsSerie() {
 
 async function loadExploitationsDocuments() {
   const csvContent = await fs.readFile('data/exploitation-document.csv', 'utf8')
-  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
-
-  return rows
-}
-
-async function loadBss() {
-  const csvContent = await fs.readFile('data/bss.csv', 'utf8')
-  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
-
-  return rows
-}
-
-async function loadBnpe() {
-  const csvContent = await fs.readFile('data/point-prelevement-bnpe.csv', 'utf8')
   const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
 
   return rows
@@ -315,13 +317,21 @@ export const resultatsSuivi = await readDataFromCsvFile(
   RESULTATS_DEFINITION
 )
 
+export const bss = await readDataFromCsvFile(
+  'data/bss.csv',
+  BSS_DEFINITION
+)
+
+export const bnpe = await readDataFromCsvFile(
+  'data/bnpe.csv',
+  BNPE_DEFINITION
+)
+
 export const exploitationsRegles = await loadExploitationsRegles()
 export const exploitationsDocuments = await loadExploitationsDocuments()
 export const exploitationModalites = await loadExploitationsModalitesSuivis()
 export const exploitationsUsage = await loadExploitationsUsage()
 export const exploitationsSerie = await loadExploitationsSerie()
-export const bss = await loadBss()
-export const bnpe = await loadBnpe()
 
 export const indexedExploitations = keyBy(exploitations, 'id_exploitation')
 export const indexedPointsPrelevement = keyBy(pointsPrelevement, 'id_point')

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -240,7 +240,7 @@ const BSS_DEFINITION = {
 const BNPE_DEFINITION = {
   schema: {
     code_point_prelevement: {parse: parseString},
-    url_ouvrage: {parse: parseString}
+    uri_ouvrage: {parse: parseString}
   },
   requiredFields: ['code_point_prelevement']
 }
@@ -341,4 +341,5 @@ export const indexedDocuments = keyBy(documents, 'id_document')
 export const indexedModalitesSuivis = keyBy(modalitesSuivis, 'id_modalite')
 export const indexedSeriesDonnees = keyBy(serieDonnees, 'id_serie')
 export const indexedBss = keyBy(bss, 'id_bss')
-export const indexedBnpeByPointPrelevement = keyBy(bnpe, 'code_point_prelevement')
+// Le champ est nommé "code_point_prelevement" mais c'est bien le code bnpe
+export const indexedBnpe = keyBy(bnpe, 'code_point_prelevement')

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -51,7 +51,7 @@ function parseDate(value) {
   console.warn(`Unknown date format: ${value || 'VIDE'}`)
 }
 
-function parseNomenclature(value, nomenclature) {
+export function parseNomenclature(value, nomenclature) {
   if (!nomenclature[value] || value === '') {
     console.warn(`Valeur inconnue dans la nomenclature: ${value || 'VIDE'}`)
   }

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -3,7 +3,7 @@ import {keyBy} from 'lodash-es'
 import Papa from 'papaparse'
 
 import {extractGeometry} from '../../util/extract-geom.js'
-import {typesMilieu, statutsExploitation, parametres, unites, contraintes, natures, frequences, traitements} from '../../nomenclature.js'
+import {typesMilieu, statutsExploitation, parametres, unites, contraintes, natures, frequences, traitements, precisionsGeom} from '../../nomenclature.js'
 
 /* Parsers */
 
@@ -97,7 +97,7 @@ const POINTS_PRELEVEMENT_DEFINITION = {
     code_bnpe: {parse: parseString},
     id_bss: {parse: parseString},
     code_aiot: {parse: parseString},
-    type_milieu: {parse: value => typesMilieu[value] || null},
+    type_milieu: {parse: value => parseNomenclature(value, typesMilieu)},
     profondeur: {parse: parseNumber},
     zre: {parse: parseBoolean},
     reservoir_biologique: {parse: parseBoolean},
@@ -109,7 +109,7 @@ const POINTS_PRELEVEMENT_DEFINITION = {
     cours_eau: {parse: parseString},
     detail_localisation: {parse: parseString},
     geom: {parse: extractGeometry},
-    precision_geom: {drop: true},
+    precision_geom: {parse: value => parseNomenclature(value, precisionsGeom)},
     remarque: {parse: parseString}
   },
   requiredFields: ['id_point', 'nom', 'geom']
@@ -120,7 +120,7 @@ const EXPLOITATIONS_DEFINITION = {
     id_exploitation: {parse: parseString},
     date_debut: {parse: parseDate},
     date_fin: {parse: parseDate},
-    statut: {parse: value => statutsExploitation[value] || null},
+    statut: {parse: value => parseNomenclature(value, statutsExploitation)},
     raison_abandon: {parse: parseString},
     remarque: {parse: parseString},
     id_point: {parse: parseString},

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -257,6 +257,13 @@ async function loadExploitationsSerie() {
   return rows
 }
 
+async function loadExploitationsDocuments() {
+  const csvContent = await fs.readFile('data/exploitation-document.csv', 'utf8')
+  const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
+
+  return rows
+}
+
 // Initialisation
 export const beneficiaires = await readDataFromCsvFile(
   'data/beneficiaire.csv',
@@ -295,6 +302,7 @@ export const resultatsSuivi = await readDataFromCsvFile(
 )
 
 export const exploitationsRegles = await loadExploitationsRegles()
+export const exploitationsDocuments = await loadExploitationsDocuments()
 export const exploitationModalites = await loadExploitationsModalitesSuivis()
 export const exploitationsUsage = await loadExploitationsUsage()
 export const exploitationsSerie = await loadExploitationsSerie()

--- a/lib/models/internal/in-memory.js
+++ b/lib/models/internal/in-memory.js
@@ -245,6 +245,15 @@ const BNPE_DEFINITION = {
   requiredFields: ['code_point_prelevement']
 }
 
+const LIBELLES_DEFINITION = {
+  schema: {
+    id: {parse: parseString},
+    insee_com: {parse: parseString},
+    nom: {parse: parseString}
+  },
+  requiredFields: ['id']
+}
+
 async function loadExploitationsRegles() {
   const csvContent = await fs.readFile('data/exploitation-regle.csv', 'utf8')
   const {data: rows} = Papa.parse(csvContent, {header: true, skipEmptyLines: true})
@@ -327,6 +336,11 @@ export const bnpe = await readDataFromCsvFile(
   BNPE_DEFINITION
 )
 
+export const libellesCommunes = await readDataFromCsvFile(
+  'data/commune.csv',
+  LIBELLES_DEFINITION
+)
+
 export const exploitationsRegles = await loadExploitationsRegles()
 export const exploitationsDocuments = await loadExploitationsDocuments()
 export const exploitationModalites = await loadExploitationsModalitesSuivis()
@@ -343,3 +357,4 @@ export const indexedSeriesDonnees = keyBy(serieDonnees, 'id_serie')
 export const indexedBss = keyBy(bss, 'id_bss')
 // Le champ est nommé "code_point_prelevement" mais c'est bien le code bnpe
 export const indexedBnpe = keyBy(bnpe, 'code_point_prelevement')
+export const indexedLibellesCommunes = keyBy(libellesCommunes, 'insee_com')

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -27,10 +27,11 @@ export async function getExploitationsFromPointId(idPoint) {
         r.document = storage.documents.find(d => d.id_document === r.id_document) || []
       }
 
-      exploitation.documents = storage.exploitationsDocuments.filter(ed => ed.id_exploitation === exploitation.id_exploitation) || []
-      exploitation.documents = exploitation.documents.map(ed => (
-        storage.documents.find(d => d.id_document === ed.id_document)
-      ))
+      exploitation.documents = storage.exploitationsDocuments
+        .filter(ed => ed.id_exploitation === exploitation.id_exploitation)
+        .map(ed => (
+          storage.documents.find(d => d.id_document === ed.id_document)
+        ))
 
       // Importation des modalités dans exploitation
       exploitation.modalites = storage.exploitationModalites.filter(e => e.id_exploitation === exploitation.id_exploitation) || []

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -130,6 +130,14 @@ export async function getPointPrelevement(idPoint) {
     beneficiaires: await getBeneficiairesFromPointId(idPoint),
     exploitations,
     usages: uniq(usagesWithDuplicates),
-    typeMilieu: point.type_milieu
+    typeMilieu: point?.type_milieu
   }
+}
+
+export async function getBssById(idBss) {
+  return storage.indexedBss[idBss]
+}
+
+export async function getBnpeByPointPrelevementId(idPoint) {
+  return storage.indexedBnpeByPointPrelevement[idPoint]
 }

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -109,7 +109,7 @@ export async function getDocumentFromRegleId(idRegle) {
 export async function getPointsPrelevement() {
   const pointsPrelevement = await Promise.all(storage.pointsPrelevement.map(async point => {
     const exploitations = await getExploitationsFromPointId(point.id_point)
-    const usagesWithDuplicates = exploitations.map(e => usages[e.usage])
+    const usagesWithDuplicates = exploitations.map(e => e.usage)
 
     return ({
       ...point,

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -64,6 +64,12 @@ export async function getExploitation(idExploitation) {
   return storage.indexedExploitations[idExploitation]
 }
 
+export async function getDocumentFromExploitationId(idExploitation) {
+  return storage.exploitationsDocuments
+    .filter(ed => ed.id_exploitation === idExploitation)
+    .map(ed => storage.indexedDocuments[ed.id_document])
+}
+
 export async function getReglesFromExploitationId(idExploitation) {
   return storage.exploitationsRegles
     .filter(r => r.id_exploitation === idExploitation)

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -9,10 +9,6 @@ export async function getBeneficiairesFromPointId(idPoint) {
     .map(exploitation => storage.indexedBeneficiaires[exploitation.id_beneficiaire])
 }
 
-export async function getBeneficiairesFromExploitationId(idExploitation) {
-  return storage.beneficiaires.find(b => b.id_beneficiaire === idExploitation)
-}
-
 export async function getExploitationsFromPointId(idPoint) {
   return storage.exploitations
     .filter(e => e.id_point === idPoint)

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -30,6 +30,11 @@ export async function getExploitationsFromPointId(idPoint) {
         r.document = storage.documents.find(d => d.id_document === r.id_document) || []
       }
 
+      exploitation.documents = storage.exploitationsDocuments.filter(ed => ed.id_exploitation === exploitation.id_exploitation) || []
+      exploitation.documents = exploitation.documents.map(ed => (
+        storage.documents.find(d => d.id_document === ed.id_document)
+      ))
+
       // Importation des modalités dans exploitation
       exploitation.modalites = storage.exploitationModalites.filter(e => e.id_exploitation === exploitation.id_exploitation) || []
       exploitation.modalites = exploitation.modalites.map(m => (

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -148,4 +148,7 @@ export async function getBssById(idBss) {
 export async function getBnpe(id) {
   return storage.indexedBnpe[id]
 }
+
+export async function getCommune(codeInsee) {
+  return storage.indexedLibellesCommunes[codeInsee]
 }

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -138,6 +138,7 @@ export async function getBssById(idBss) {
   return storage.indexedBss[idBss]
 }
 
-export async function getBnpeByPointPrelevementId(idPoint) {
-  return storage.indexedBnpeByPointPrelevement[idPoint]
+export async function getBnpe(id) {
+  return storage.indexedBnpe[id]
+}
 }

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -43,6 +43,7 @@ export async function getExploitationsFromPointId(idPoint) {
 
       // Importations des usages dans exploitation
       exploitation.usage = storage.exploitationsUsage.find(u => u.id_exploitation === exploitation.id_exploitation).id_usage
+      exploitation.usage = usages[exploitation.usage]
 
       // Importation des séries dans exploitation
       exploitation.series = storage.exploitationsSerie.filter(e => e.id_exploitation === exploitation.id_exploitation) || []

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -2,6 +2,7 @@ import {uniq} from 'lodash-es'
 
 import * as storage from './internal/in-memory.js'
 import {usages} from '../nomenclature.js'
+import {parseNomenclature} from '../../lib/models/internal/in-memory.js'
 
 export async function getBeneficiairesFromPointId(idPoint) {
   return storage.exploitations
@@ -39,7 +40,7 @@ export async function getExploitationsFromPointId(idPoint) {
 
       // Importations des usages dans exploitation
       exploitation.usage = storage.exploitationsUsage.find(u => u.id_exploitation === exploitation.id_exploitation).id_usage
-      exploitation.usage = usages[exploitation.usage]
+      exploitation.usage = parseNomenclature(exploitation.usage, usages)
 
       // Importation des séries dans exploitation
       exploitation.series = storage.exploitationsSerie.filter(e => e.id_exploitation === exploitation.id_exploitation) || []

--- a/lib/nomenclature.js
+++ b/lib/nomenclature.js
@@ -84,3 +84,19 @@ export const traitements = {
   3: 'moyenne',
   4: 'différence d’index'
 }
+
+export const precisionsGeom = {
+  1: 'Repérage carte',
+  2: 'Coordonnées précises',
+  3: 'Coordonnées précises (ARS)',
+  4: 'Coordonnées du centroïde de la commune',
+  5: 'Coordonnées précises (rapport HGA)',
+  6: 'Coordonnées précises (ARS 2013)',
+  7: 'Coordonnées précises (AP)',
+  8: 'Coordonnées précises (BSS)',
+  9: 'Coordonnées précises (BNPE – accès restreint)',
+  10: 'Précision inconnue',
+  11: 'Coordonnées estimées (précision du kilomètre)',
+  12: 'Coordonnées précises (BNPE)',
+  13: 'Coordonnées précises (DEAL)'
+}

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -27,6 +27,7 @@ import {
   getDocumentFromRegleId,
   getBssById,
   getBnpe,
+  getDocumentFromExploitationId
 } from './models/points-prelevement.js'
 
 export const handleDossier = w(async (req, res, next) => {
@@ -136,6 +137,12 @@ async function createRoutes() {
     const beneficiaires = await getBeneficiairesFromExploitationId(req.params.id)
 
     res.send(beneficiaires)
+  }))
+
+  app.get('/exploitations/:id/documents', w(async (req, res) => {
+    const documents = await getDocumentFromExploitationId(req.params.id)
+
+    res.send(documents)
   }))
 
   app.get('/exploitations/:id/regles', w(async (req, res) => {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -27,6 +27,7 @@ import {
   getDocumentFromRegleId,
   getBssById,
   getBnpe,
+  getCommune,
   getDocumentFromExploitationId
 } from './models/points-prelevement.js'
 
@@ -205,6 +206,10 @@ async function createRoutes() {
     res.send(bnpe)
   }))
 
+  app.get('/commune/:codeInsee', w(async (req, res) => {
+    const commune = await getCommune(req.params.codeInsee)
+
+    res.send(commune)
   }))
 
   return app

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -19,7 +19,6 @@ import {
   getRegle,
   getDocument,
   getModalitesFromExploitationId,
-  getBeneficiairesFromExploitationId,
   getSeriesFromExploitationId,
   getExploitationsFromPointId,
   getBeneficiairesFromPointId,
@@ -132,12 +131,6 @@ async function createRoutes() {
     const exploitation = await getExploitation(req.params.id)
 
     res.send(exploitation)
-  }))
-
-  app.get('/exploitations/:id/beneficiaires', w(async (req, res) => {
-    const beneficiaires = await getBeneficiairesFromExploitationId(req.params.id)
-
-    res.send(beneficiaires)
   }))
 
   app.get('/exploitations/:id/documents', w(async (req, res) => {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -26,7 +26,7 @@ import {
   getResultatsFromSerieId,
   getDocumentFromRegleId,
   getBssById,
-  getBnpeByPointPrelevementId
+  getBnpe,
 } from './models/points-prelevement.js'
 
 export const handleDossier = w(async (req, res, next) => {
@@ -193,9 +193,11 @@ async function createRoutes() {
   }))
 
   app.get('/bnpe/:id', w(async (req, res) => {
-    const ouvrage = await getBnpeByPointPrelevementId(req.params.id)
+    const bnpe = await getBnpe(req.params.id)
 
-    res.send(ouvrage)
+    res.send(bnpe)
+  }))
+
   }))
 
   return app

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -24,7 +24,9 @@ import {
   getExploitationsFromPointId,
   getBeneficiairesFromPointId,
   getResultatsFromSerieId,
-  getDocumentFromRegleId
+  getDocumentFromRegleId,
+  getBssById,
+  getBnpeByPointPrelevementId
 } from './models/points-prelevement.js'
 
 export const handleDossier = w(async (req, res, next) => {
@@ -182,6 +184,18 @@ async function createRoutes() {
     const document = await getDocument(req.params.id)
 
     res.send(document)
+  }))
+
+  app.get('/bss/:id', w(async (req, res) => {
+    const bss = await getBssById(req.params.id)
+
+    res.send(bss)
+  }))
+
+  app.get('/bnpe/:id', w(async (req, res) => {
+    const ouvrage = await getBnpeByPointPrelevementId(req.params.id)
+
+    res.send(ouvrage)
   }))
 
   return app

--- a/scripts/download-csv.js
+++ b/scripts/download-csv.js
@@ -25,7 +25,11 @@ const filenames = [
   'exploitation-modalite-suivi.csv',
   'exploitation-serie.csv',
   'serie-donnees.csv',
-  'resultat-suivi.csv'
+  'resultat-suivi.csv',
+  'bnpe.csv',
+  'bss.csv',
+  'commune.csv',
+  'exploitation-document.csv'
 ]
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))


### PR DESCRIPTION
Cette PR ajoute quelques fonctionnalités nécessaires pour l'[issue 8](https://github.com/MTES-MCT/prelevement-deau-front/issues/8).

- Ajout d'une nouvelle nomenclature pour la précision géométrique
- Correction des définitions de "points-prelevement" et "exploitations"
- Ajout des définitions / getters / routes pour BSS / BPE / Libellé adresse
- Ajout d'une fonction pour récupérer les documents d'une exploitation
- Ajout des usages (en chaine de caractères) dans les exploitations
- Suppression d'une fonction qui ne fonctionnait pas

> Cette PR a besoin des nouveaux fichiers csv : 
> - bnpe.csv
> - bss.csv
> - commune.csv
> - exploitation-document.csv
> - ouvrage-bnpe.csv