### PR TITLE
Retire `exploitations` de l'objet `pointPrelevement`

### DIFF
--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -1,4 +1,4 @@
-import {uniq} from 'lodash-es'
+import {orderBy, uniq} from 'lodash-es'
 
 import * as storage from './internal/in-memory.js'
 import {usages} from '../nomenclature.js'
@@ -111,14 +111,15 @@ export async function getDocumentFromRegleId(idRegle) {
 export async function getPointsPrelevement() {
   const pointsPrelevement = await Promise.all(storage.pointsPrelevement.map(async point => {
     const exploitations = await getExploitationsFromPointId(point.id_point)
+    const exploitationOrderedByDate = orderBy(exploitations, 'date_debut', 'asc')
     const usagesWithDuplicates = exploitations.map(e => e.usage)
 
     return ({
       ...point,
       beneficiaires: await getBeneficiairesFromPointId(point.id_point),
-      exploitations,
-      usages: uniq(usagesWithDuplicates),
-      typeMilieu: point.type_milieu
+      exploitationsStatus: exploitationOrderedByDate.at(-1).statut,
+      exploitationsStartDate: exploitationOrderedByDate[0].date_debut,
+      usages: uniq(usagesWithDuplicates)
     })
   }))
 


### PR DESCRIPTION
Le chargement de la carte côté client est assez long parce que l'objet `pointPrelevement` contient trop d'information.

Cette PR retire le champ `exploitations` de l'objet `pointPrelevement`.
Elle ajoute deux champs `exploitationsStatus` et `exploitationsStartDate` afin de conserver l'affichage côté client.

> ⚠️ Cette Pr doit être mergé en même temps que la [PR front](https://github.com/MTES-MCT/prelevement-deau-front/pull/21)