### PR TITLE
Ajout de route pour la nouvelle page "préleveurs"

### DIFF
--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -87,7 +87,39 @@ export async function getSeriesFromExploitationId(idExploitation) {
 }
 
 export async function getBeneficiaire(idBeneficiaire) {
-  return storage.indexedBeneficiaires[idBeneficiaire]
+  const beneficiaire = storage.indexedBeneficiaires[idBeneficiaire]
+  const exploitations = storage.exploitations.filter(e => e.id_beneficiaire === idBeneficiaire)
+  const exploitationsWithUsage = exploitations.map(exploitation => ({
+    ...exploitation,
+    usage: storage.exploitationsUsage.find(u => u.id_exploitation === exploitation.id_exploitation)
+  }))
+  const exploitationsWithNamedUsages = exploitationsWithUsage.map(exploitation => ({
+    ...exploitation,
+    usage: parseNomenclature(exploitation.usage.id_usage, usages)
+  }))
+
+  return {
+    ...beneficiaire,
+    exploitations: exploitationsWithNamedUsages
+  }
+}
+
+export async function getBeneficiaires() {
+  const {beneficiaires} = storage
+
+  for (const b of beneficiaires) {
+    const exploitations = storage.exploitations.filter(e => e.id_beneficiaire === b.id_beneficiaire)
+    const exploitationsUsages = exploitations.map(e => (
+      storage.exploitationsUsage.find(u => u.id_exploitation === e.id_exploitation)
+    ))
+    const exploitationsWithNamedUsages = exploitationsUsages.map(e => (
+      parseNomenclature(e.id_usage, usages)
+    ))
+
+    b.usages = uniq(exploitationsWithNamedUsages)
+  }
+
+  return beneficiaires
 }
 
 export async function getRegle(idRegle) {
@@ -138,6 +170,14 @@ export async function getPointPrelevement(idPoint) {
     usages: uniq(usagesWithDuplicates),
     typeMilieu: point?.type_milieu
   }
+}
+
+export async function getPointsFromBeneficiaire(idBeneficiaire) {
+  const exploitations = storage.exploitations.filter(e => e.id_beneficiaire === idBeneficiaire)
+  const pointsPromises = exploitations.map(e => getPointPrelevement(e.id_point))
+  const points = await Promise.all(pointsPromises)
+
+  return points
 }
 
 export async function getBssById(idBss) {

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -87,31 +87,25 @@ export async function getSeriesFromExploitationId(idExploitation) {
 }
 
 export async function getBeneficiaireExploitations(idBeneficiaire) {
-  const exploitations = storage.exploitations
+  return storage.exploitations
     .filter(e => e.id_beneficiaire === idBeneficiaire)
-    .map(exploitation => ({
-      ...exploitation,
-      usage: storage.exploitationsUsage.find(u => u.id_exploitation === exploitation.id_exploitation)
-    }))
-
-  return exploitations.map(exploitation => ({
-    ...exploitation,
-    usage: parseNomenclature(exploitation.usage.id_usage, usages)
-  }))
+    .map(exploitation => {
+      const usage = storage.exploitationsUsage.find(u => u.id_exploitation === exploitation.id_exploitation)
+      return {
+        ...exploitation,
+        usage: parseNomenclature(usage.id_usage, usages)
+      }
+    })
 }
 
 // Récupérer les usages de chaque exploitation
 export function getUsagesFromExploitations(exploitations) {
-  const usagesArray = []
-  const usagesIndex = exploitations
-    .map(e => storage.exploitationsUsage
-      .find(u => u.id_exploitation === e.id_exploitation))
+  const usagesFromExploitations = exploitations.map(e => {
+    const usageEntry = storage.exploitationsUsage.find(u => u.id_exploitation === e.id_exploitation)
+    return parseNomenclature(usageEntry.id_usage, usages)
+  })
 
-  for (const usage of usagesIndex) {
-    usagesArray.push(parseNomenclature(usage.id_usage, usages))
-  }
-
-  return uniq(usagesArray)
+  return uniq(usagesFromExploitations)
 }
 
 export async function getBeneficiaire(idBeneficiaire) {
@@ -127,20 +121,7 @@ export async function getBeneficiaire(idBeneficiaire) {
 }
 
 export async function getBeneficiaires() {
-  const {beneficiaires} = storage
-
-  const updatedBeneficiaires = await Promise.all(
-    beneficiaires.map(async originalBeneficiaires => {
-      const b = {...originalBeneficiaires}
-
-      b.exploitations = await getBeneficiaireExploitations(b.id_beneficiaire)
-      b.usages = getUsagesFromExploitations(b.exploitations)
-
-      return b
-    })
-  )
-
-  return updatedBeneficiaires
+  return Promise.all(storage.beneficiaires.map(b => getBeneficiaire(b.id_beneficiaire)))
 }
 
 export async function getRegle(idRegle) {

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -86,40 +86,58 @@ export async function getSeriesFromExploitationId(idExploitation) {
     .map(s => storage.indexedSeriesDonnees[s.id_serie])
 }
 
-export async function getBeneficiaire(idBeneficiaire) {
-  const beneficiaire = storage.indexedBeneficiaires[idBeneficiaire]
-  const exploitations = storage.exploitations.filter(e => e.id_beneficiaire === idBeneficiaire)
-  const exploitationsWithUsage = exploitations.map(exploitation => ({
-    ...exploitation,
-    usage: storage.exploitationsUsage.find(u => u.id_exploitation === exploitation.id_exploitation)
-  }))
-  const exploitationsWithNamedUsages = exploitationsWithUsage.map(exploitation => ({
+export async function getBeneficiaireExploitations(idBeneficiaire) {
+  const exploitations = storage.exploitations
+    .filter(e => e.id_beneficiaire === idBeneficiaire)
+    .map(exploitation => ({
+      ...exploitation,
+      usage: storage.exploitationsUsage.find(u => u.id_exploitation === exploitation.id_exploitation)
+    }))
+
+  return exploitations.map(exploitation => ({
     ...exploitation,
     usage: parseNomenclature(exploitation.usage.id_usage, usages)
   }))
+}
+
+// Récupérer les usages de chaque exploitation
+export function getUsagesFromExploitations(exploitations) {
+  const usagesArray = []
+  const usagesIndex = exploitations
+    .map(e => storage.exploitationsUsage
+      .find(u => u.id_exploitation === e.id_exploitation))
+
+  for (const usage of usagesIndex) {
+    usagesArray.push(parseNomenclature(usage.id_usage, usages))
+  }
+
+  return uniq(usagesArray)
+}
+
+export async function getBeneficiaire(idBeneficiaire) {
+  const beneficiaire = storage.indexedBeneficiaires[idBeneficiaire]
+  const exploitations = await getBeneficiaireExploitations(idBeneficiaire)
+  const usages = getUsagesFromExploitations(exploitations)
 
   return {
     ...beneficiaire,
-    exploitations: exploitationsWithNamedUsages
+    exploitations,
+    usages
   }
 }
 
 export async function getBeneficiaires() {
-  const {beneficiaires} = storage
+  const beneficiairesCopy = storage.beneficiaires
 
-  for (const b of beneficiaires) {
-    const exploitations = storage.exploitations.filter(e => e.id_beneficiaire === b.id_beneficiaire)
-    const exploitationsUsages = exploitations.map(e => (
-      storage.exploitationsUsage.find(u => u.id_exploitation === e.id_exploitation)
-    ))
-    const exploitationsWithNamedUsages = exploitationsUsages.map(e => (
-      parseNomenclature(e.id_usage, usages)
-    ))
+  const updatedBeneficiaires = await Promise.all(
+    beneficiairesCopy.map(async b => {
+      b.exploitations = await getBeneficiaireExploitations(b.id_beneficiaire)
+      b.usages = getUsagesFromExploitations(b.exploitations)
+      return b
+    })
+  )
 
-    b.usages = uniq(exploitationsWithNamedUsages)
-  }
-
-  return beneficiaires
+  return updatedBeneficiaires
 }
 
 export async function getRegle(idRegle) {

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -127,12 +127,15 @@ export async function getBeneficiaire(idBeneficiaire) {
 }
 
 export async function getBeneficiaires() {
-  const beneficiairesCopy = storage.beneficiaires
+  const {beneficiaires} = storage
 
   const updatedBeneficiaires = await Promise.all(
-    beneficiairesCopy.map(async b => {
+    beneficiaires.map(async originalBeneficiaires => {
+      const b = {...originalBeneficiaires}
+
       b.exploitations = await getBeneficiaireExploitations(b.id_beneficiaire)
       b.usages = getUsagesFromExploitations(b.exploitations)
+
       return b
     })
   )

--- a/lib/nomenclature.js
+++ b/lib/nomenclature.js
@@ -19,7 +19,8 @@ export const typesMilieu = {
 export const statutsExploitation = {
   1: 'En activité',
   2: 'Terminée',
-  3: 'Abandonnée'
+  3: 'Abandonnée',
+  4: 'Non renseigné'
 }
 
 export const unites = {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -11,9 +11,11 @@ import * as Dossier from './models/dossier.js'
 import {
   getPointsPrelevement,
   getPointPrelevement,
+  getPointsFromBeneficiaire,
   getExploitation,
   getReglesFromExploitationId,
   getBeneficiaire,
+  getBeneficiaires,
   getRegle,
   getDocument,
   getModalitesFromExploitationId,
@@ -150,10 +152,22 @@ async function createRoutes() {
     res.send(resultats)
   }))
 
+  app.get('/beneficiaires', w(async (req, res) => {
+    const beneficiaires = await getBeneficiaires()
+
+    res.send(beneficiaires)
+  }))
+
   app.get('/beneficiaires/:id', w(async (req, res) => {
     const beneficiaire = await getBeneficiaire(req.params.id)
 
     res.send(beneficiaire)
+  }))
+
+  app.get('/beneficiaires/:id/points-prelevement', w(async (req, res) => {
+    const points = await getPointsFromBeneficiaire(req.params.id)
+
+    res.send(points)
   }))
 
   app.get('/regles/:id', w(async (req, res) => {


### PR DESCRIPTION
Cette PR ajoute deux routes pour récupérer les informations nécessaires à la nouvelle page "préleveurs".

- Une route pour récupérer la liste complète des préleveurs.
- Une route pour récupérer les points de prélèvement à partir de l'id d'un préleveur

J'en ai profité pour mettre à jour la nomenclature qui renvoyait beaucoup d'erreur parce qu'il manquait un champ.

