### PR TITLE
Ajout de fonctions pour la route `/stats`

### DIFF
--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -1,6 +1,7 @@
 import {chain, uniq} from 'lodash-es'
 
 import * as storage from './internal/in-memory.js'
+import {parametres, typesMilieu} from '../nomenclature.js'
 
 import {getBeneficiairesFromPointId} from './beneficiaire.js'
 import {getExploitationsFromPointId} from './exploitation.js'
@@ -66,15 +67,14 @@ export async function getSeriesFromExploitationId(idExploitation) {
     .map(s => storage.indexedSeriesDonnees[s.id_serie])
 }
 
-export async function getStats() {
-  // Fonctions pour récupérer les stats "Régularisations"
+function getRegularisationsStats() {
   function getActiveDocuments() {
     const today = new Date()
     const activeDocuments = storage.documents.filter(doc => !doc.date_fin_validite || new Date(doc.date_fin_validite) >= today)
     return activeDocuments
   }
 
-  function createBilan() {
+  function createBilanRegularisations() {
     const activeDocuments = getActiveDocuments()
     const bilanMap = new Map()
 
@@ -119,7 +119,7 @@ export async function getStats() {
     return bilan
   }
 
-  function countExploitations(bilan, criteria) {
+  function countExploitationsRegularisation(bilan, criteria) {
     const exploitationsSet = new Set()
     for (const b of bilan) {
       if (criteria(b)) {
@@ -131,55 +131,128 @@ export async function getStats() {
   }
 
   function getRegularisations() {
-    const bilan = createBilan()
+    const bilan = createBilanRegularisations()
     const results = []
-
-    // CSP
     const csp = {
       regime: 'CSP',
-      nb_exploitations_concernees: countExploitations(bilan, b => b.liste_usages.split(',').includes('1')),
-      nb_exploitations_autorisees: countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP') || b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA')),
-      nb_exploitations_non_autorisees: countExploitations(bilan, b => b.liste_usages.split(',').includes('1')) - countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP') || b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA'))
+      nb_exploitations_concernees: countExploitationsRegularisation(bilan, b => b.liste_usages.split(',').includes('1')),
+      nb_exploitations_autorisees: countExploitationsRegularisation(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP') || b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA')),
+      nb_exploitations_non_autorisees: countExploitationsRegularisation(bilan, b => b.liste_usages.split(',').includes('1')) - countExploitationsRegularisation(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP') || b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA'))
     }
-
-    // Hydroélectricité
     const hydroelectricite = {
       regime: 'Hydroélectricité',
-      nb_exploitations_concernees: countExploitations(bilan, b => b.liste_usages.split(',').includes('6')),
-      nb_exploitations_autorisees: countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation hydroélectricité')),
-      nb_exploitations_non_autorisees: countExploitations(bilan, b => b.liste_usages.split(',').includes('6')) - countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation hydroélectricité'))
+      nb_exploitations_concernees: countExploitationsRegularisation(bilan, b => b.liste_usages.split(',').includes('6')),
+      nb_exploitations_autorisees: countExploitationsRegularisation(bilan, b => b.liste_nature_document.split(',').includes('Autorisation hydroélectricité')),
+      nb_exploitations_non_autorisees: countExploitationsRegularisation(bilan, b => b.liste_usages.split(',').includes('6')) - countExploitationsRegularisation(bilan, b => b.liste_nature_document.split(',').includes('Autorisation hydroélectricité'))
     }
-
-    // ICPE
     const icpe = {
       regime: 'ICPE',
-      nb_exploitations_concernees: countExploitations(bilan, b => b.liste_usages.split(',').includes('5') || b.liste_usages.split(',').includes('7') || b.liste_usages.split(',').includes('9')),
-      nb_exploitations_autorisees: countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation ICPE')),
-      nb_exploitations_non_autorisees: countExploitations(bilan, b => b.liste_usages.split(',').includes('5') || b.liste_usages.split(',').includes('7') || b.liste_usages.split(',').includes('9')) - countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation ICPE'))
+      nb_exploitations_concernees: countExploitationsRegularisation(bilan, b => b.liste_usages.split(',').includes('5') || b.liste_usages.split(',').includes('7') || b.liste_usages.split(',').includes('9')),
+      nb_exploitations_autorisees: countExploitationsRegularisation(bilan, b => b.liste_nature_document.split(',').includes('Autorisation ICPE')),
+      nb_exploitations_non_autorisees: countExploitationsRegularisation(bilan, b => b.liste_usages.split(',').includes('5') || b.liste_usages.split(',').includes('7') || b.liste_usages.split(',').includes('9')) - countExploitationsRegularisation(bilan, b => b.liste_nature_document.split(',').includes('Autorisation ICPE'))
     }
-
-    // AOT
     const aot = {
       regime: 'AOT',
-      nb_exploitations_concernees: countExploitations(bilan, () => true),
-      nb_exploitations_autorisees: countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation AOT')),
-      nb_exploitations_non_autorisees: countExploitations(bilan, () => true) - countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation AOT'))
+      nb_exploitations_concernees: countExploitationsRegularisation(bilan, () => true),
+      nb_exploitations_autorisees: countExploitationsRegularisation(bilan, b => b.liste_nature_document.split(',').includes('Autorisation AOT')),
+      nb_exploitations_non_autorisees: countExploitationsRegularisation(bilan, () => true) - countExploitationsRegularisation(bilan, b => b.liste_nature_document.split(',').includes('Autorisation AOT'))
     }
-
-    // IOTA
     const iota = {
       regime: 'IOTA',
-      nb_exploitations_concernees: countExploitations(bilan, b => b.liste_usages.split(',').includes('1') || b.liste_usages.split(',').includes('2') || b.liste_usages.split(',').includes('3') || b.liste_usages.split(',').includes('8')),
-      nb_exploitations_autorisees: countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA') || b.liste_nature_document.split(',').includes('Autorisation IOTA')),
-      nb_exploitations_non_autorisees: countExploitations(bilan, b => b.liste_usages.split(',').includes('1') || b.liste_usages.split(',').includes('2') || b.liste_usages.split(',').includes('3') || b.liste_usages.split(',').includes('8')) - countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA') || b.liste_nature_document.split(',').includes('Autorisation IOTA'))
+      nb_exploitations_concernees: countExploitationsRegularisation(bilan, b => b.liste_usages.split(',').includes('1') || b.liste_usages.split(',').includes('2') || b.liste_usages.split(',').includes('3') || b.liste_usages.split(',').includes('8')),
+      nb_exploitations_autorisees: countExploitationsRegularisation(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA') || b.liste_nature_document.split(',').includes('Autorisation IOTA')),
+      nb_exploitations_non_autorisees: countExploitationsRegularisation(bilan, b => b.liste_usages.split(',').includes('1') || b.liste_usages.split(',').includes('2') || b.liste_usages.split(',').includes('3') || b.liste_usages.split(',').includes('8')) - countExploitationsRegularisation(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA') || b.liste_nature_document.split(',').includes('Autorisation IOTA'))
     }
 
     results.push(csp, hydroelectricite, icpe, aot, iota)
 
     return results.sort((a, b) => b.nb_exploitations_concernees - a.nb_exploitations_concernees)
   }
-  // Fin des fonctions pour "Régularisations"
 
+  return getRegularisations()
+}
+
+function getDebitsReservesStats() {
+  function getActiveRegles() {
+    const today = new Date()
+    const activeRegles = storage.regles.filter(r => !r.fin_validite || new Date(r.fin_validite) >= today)
+    return activeRegles
+  }
+
+  function createBilan() {
+    const activeRegles = getActiveRegles()
+    const bilanMap = new Map()
+
+    for (const e of storage.exploitations) {
+      if (e.statut === 'En activité' || e.statut === 'Non renseigné') {
+        const {id_exploitation} = e
+        const {id_point} = e
+        const point = storage.pointsPrelevement.find(p => p.id_point === id_point)
+
+        if (point
+          && point.type_milieu === 'Eau de surface'
+          && !point.nom.toLowerCase().includes('source')
+          && !point.nom.toLowerCase().includes('camions citernes')
+        ) {
+          const liste_parametres = new Set()
+
+          for (const er of storage.exploitationsRegles) {
+            if (er.id_exploitation === id_exploitation) {
+              const regle = activeRegles
+                .find(r => r.id_regle === er.id_regle)
+              if (regle) {
+                liste_parametres.add(regle.parametre)
+              }
+            }
+          }
+
+          const hasDebitReserve = [...liste_parametres]
+            .some(param => param.includes('Débit réservé'))
+
+          const debitReserve = hasDebitReserve
+            ? 'Débit réservé défini'
+            : 'Pas de débit réservé'
+
+          bilanMap.set(id_exploitation, {
+            id_exploitation,
+            nom: point.nom,
+            debit_reserve: debitReserve
+          })
+        }
+      }
+    }
+
+    const bilan = [...bilanMap.values()]
+
+    return bilan
+  }
+
+  function countExploitations(bilan, criteria) {
+    return bilan.filter(criteria).length
+  }
+
+  function getResults() {
+    const bilan = createBilan()
+    const results = []
+
+    results.push(
+      {
+        debit_reserve: 'Débit réservé défini',
+        nb_exploitations: countExploitations(bilan, b => b.debit_reserve === 'Débit réservé défini')
+      },
+      {
+        debit_reserve: 'Pas de débit réservé',
+        nb_exploitations: countExploitations(bilan, b => b.debit_reserve === 'Pas de débit réservé')
+      }
+    )
+
+    return results
+  }
+
+  return getResults()
+}
+
+export async function getStats() {
   const activExploitations = storage.exploitations.filter(e => e.statut === 'En activité')
   const activBeneficiaires = []
   const activPoints = []
@@ -207,7 +280,8 @@ export async function getStats() {
   }))
 
   return {
-    regularisations: getRegularisations(),
+    debitsReserves: getDebitsReservesStats(),
+    regularisations: getRegularisationsStats(),
     documents: documentsWithNature,
     pointsCount: storage.pointsPrelevement.length,
     activExploitationsCount: activExploitations.length,

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -60,12 +60,6 @@ export async function getCommune(codeInsee) {
   return storage.indexedLibellesCommunes[codeInsee]
 }
 
-export async function getSeriesFromExploitationId(idExploitation) {
-  return storage.exploitationsSerie
-    .filter(s => s.id_exploitation === idExploitation)
-    .map(s => storage.indexedSeriesDonnees[s.id_serie])
-}
-
 function getRegularisationsStats() {
   function getActiveDocuments() {
     const today = new Date()

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -1,7 +1,6 @@
 import {chain, uniq} from 'lodash-es'
 
 import * as storage from './internal/in-memory.js'
-import {parametres, typesMilieu} from '../nomenclature.js'
 
 import {getBeneficiairesFromPointId} from './beneficiaire.js'
 import {getExploitationsFromPointId} from './exploitation.js'

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -87,7 +87,15 @@ export async function getStats() {
     }
   }
 
+  const documentsWithNature = storage.documents.map(d => ({
+    annee: d.date_signature.slice(0, 4),
+    nature: d.nature,
+    id: d.id_document
+  }))
+
   return {
+    documents: documentsWithNature,
+    pointsCount: storage.pointsPrelevement.length,
     activExploitationsCount: activExploitations.length,
     activPointsPrelevementCount: uniq(activPoints).length,
     activBeneficiairesCount: uniq(activBeneficiaires).length,

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -67,6 +67,119 @@ export async function getSeriesFromExploitationId(idExploitation) {
 }
 
 export async function getStats() {
+  // Fonctions pour récupérer les stats "Régularisations"
+  function getActiveDocuments() {
+    const today = new Date()
+    const activeDocuments = storage.documents.filter(doc => !doc.date_fin_validite || new Date(doc.date_fin_validite) >= today)
+    return activeDocuments
+  }
+
+  function createBilan() {
+    const activeDocuments = getActiveDocuments()
+    const bilanMap = new Map()
+
+    for (const e of storage.exploitations) {
+      if (e.statut === 'En activité' || e.statut === 'Non renseigné') {
+        const {id_exploitation} = e
+        const {id_point} = e
+        const point = storage.pointsPrelevement.find(p => p.id_point === id_point)
+
+        if (point) {
+          const liste_usages = new Set()
+          const liste_nature_document = new Set()
+
+          for (const eu of storage.exploitationsUsage) {
+            if (eu.id_exploitation === id_exploitation) {
+              liste_usages.add(eu.id_usage)
+            }
+          }
+
+          for (const ed of storage.exploitationsDocuments) {
+            if (ed.id_exploitation === id_exploitation) {
+              const doc = activeDocuments.find(d => d.id_document === ed.id_document)
+              if (doc) {
+                liste_nature_document.add(doc.nature)
+              }
+            }
+          }
+
+          bilanMap.set(id_exploitation, {
+            id_exploitation,
+            id_point,
+            nom: point.nom,
+            liste_usages: [...liste_usages].join(','),
+            liste_nature_document: [...liste_nature_document].join(',')
+          })
+        }
+      }
+    }
+
+    const bilan = [...bilanMap.values()]
+
+    return bilan
+  }
+
+  function countExploitations(bilan, criteria) {
+    const exploitationsSet = new Set()
+    for (const b of bilan) {
+      if (criteria(b)) {
+        exploitationsSet.add(b.id_exploitation)
+      }
+    }
+
+    return exploitationsSet.size
+  }
+
+  function getRegularisations() {
+    const bilan = createBilan()
+    const results = []
+
+    // CSP
+    const csp = {
+      regime: 'CSP',
+      nb_exploitations_concernees: countExploitations(bilan, b => b.liste_usages.split(',').includes('1')),
+      nb_exploitations_autorisees: countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP') || b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA')),
+      nb_exploitations_non_autorisees: countExploitations(bilan, b => b.liste_usages.split(',').includes('1')) - countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP') || b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA'))
+    }
+
+    // Hydroélectricité
+    const hydroelectricite = {
+      regime: 'Hydroélectricité',
+      nb_exploitations_concernees: countExploitations(bilan, b => b.liste_usages.split(',').includes('6')),
+      nb_exploitations_autorisees: countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation hydroélectricité')),
+      nb_exploitations_non_autorisees: countExploitations(bilan, b => b.liste_usages.split(',').includes('6')) - countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation hydroélectricité'))
+    }
+
+    // ICPE
+    const icpe = {
+      regime: 'ICPE',
+      nb_exploitations_concernees: countExploitations(bilan, b => b.liste_usages.split(',').includes('5') || b.liste_usages.split(',').includes('7') || b.liste_usages.split(',').includes('9')),
+      nb_exploitations_autorisees: countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation ICPE')),
+      nb_exploitations_non_autorisees: countExploitations(bilan, b => b.liste_usages.split(',').includes('5') || b.liste_usages.split(',').includes('7') || b.liste_usages.split(',').includes('9')) - countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation ICPE'))
+    }
+
+    // AOT
+    const aot = {
+      regime: 'AOT',
+      nb_exploitations_concernees: countExploitations(bilan, () => true),
+      nb_exploitations_autorisees: countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation AOT')),
+      nb_exploitations_non_autorisees: countExploitations(bilan, () => true) - countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation AOT'))
+    }
+
+    // IOTA
+    const iota = {
+      regime: 'IOTA',
+      nb_exploitations_concernees: countExploitations(bilan, b => b.liste_usages.split(',').includes('1') || b.liste_usages.split(',').includes('2') || b.liste_usages.split(',').includes('3') || b.liste_usages.split(',').includes('8')),
+      nb_exploitations_autorisees: countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA') || b.liste_nature_document.split(',').includes('Autorisation IOTA')),
+      nb_exploitations_non_autorisees: countExploitations(bilan, b => b.liste_usages.split(',').includes('1') || b.liste_usages.split(',').includes('2') || b.liste_usages.split(',').includes('3') || b.liste_usages.split(',').includes('8')) - countExploitations(bilan, b => b.liste_nature_document.split(',').includes('Autorisation CSP - IOTA') || b.liste_nature_document.split(',').includes('Autorisation IOTA'))
+    }
+
+    results.push(csp, hydroelectricite, icpe, aot, iota)
+
+    return results.sort((a, b) => b.nb_exploitations_concernees - a.nb_exploitations_concernees)
+  }
+  // Fin des fonctions pour "Régularisations"
+
   const activExploitations = storage.exploitations.filter(e => e.statut === 'En activité')
   const activBeneficiaires = []
   const activPoints = []
@@ -94,6 +207,7 @@ export async function getStats() {
   }))
 
   return {
+    regularisations: getRegularisations(),
     documents: documentsWithNature,
     pointsCount: storage.pointsPrelevement.length,
     activExploitationsCount: activExploitations.length,


### PR DESCRIPTION
Cette PR ajoute des fonctions permettant de récupérer des chiffres afin d'ajouter des données à la route `/stats`.

- Fonction pour récupérer les régularisations des exploitations
(Pour afficher : _Les prélèvements d'eau sont encadrés par des autorisations administratives définissant les modalités d'exploitations. Ce graphique montre le nombre de documents selon leur date de signature. Les délibérations d'abandon et rapports hydrogéologiques agréés, bien que n'étant pas des autorisations, sont également rassemblées car ils ont des incidences sur l'exploitation des points de prélèvement._)
- Fonction pour récupérer les documents associés aux exploitations
(Pour afficher : _Avancement de la régularisation administrative des exploitations en activité à ce jour. Pour chaque régime, il est indiqué le nombre d'exploitations autorisées et le nombre d'exploitations relevant de ce régime mais ne disposant pas d'autorisation à ce jour au titre de ce régime. Pour les IOTA, les chiffres doivent encore être affinés pour tenir compte des volumes effectivement prélevés par rapport aux seuils de la nomenclature IOTA. A noter qu'une exploitation peut relever de différents régimes._)
- Fonction pour récupérer les débits réservés
(Pour afficher : _Pourcentage d'exploitations dont les autorisations définissent une valeur de débit réservé. Seuls les prélèvements de surface sont pris en compte, hors sources._)