### PR TITLE
Corrige un problème dans la fonction `getBeneficiairesFromPointId`

### DIFF
--- a/lib/models/beneficiaire.js
+++ b/lib/models/beneficiaire.js
@@ -8,8 +8,17 @@ export function getBeneficiaireByEmail(email) {
 }
 
 export async function getBeneficiairesFromPointId(idPoint) {
-  return (storage.exploitationsIndexes.point[idPoint] || [])
-    .map(exploitation => storage.indexedBeneficiaires[exploitation.id_beneficiaire])
+  const exploitations = storage.exploitationsIndexes.point[idPoint] || []
+  const beneficiairesSet = new Set()
+
+  for (const exploitation of exploitations) {
+    const beneficiaire = storage.indexedBeneficiaires[exploitation.id_beneficiaire]
+    if (beneficiaire) {
+      beneficiairesSet.add(beneficiaire)
+    }
+  }
+
+  return [...beneficiairesSet]
 }
 
 export async function getBeneficiaire(idBeneficiaire) {


### PR DESCRIPTION
La fonction `getBeneficiairesFromPointId` renvoyait plusieurs fois le même préleveur, créant des erreurs dans la partie client.

Ces modifications corrigent ce problème, la fonction renvoie maintenant des préleveus uniques.

