### PR TITLE
Création d'un script pour importer les données dans mongodb

### DIFF
--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -1,5 +1,7 @@
 import {chain, uniq} from 'lodash-es'
 
+import mongo from '../util/mongo.js'
+
 import * as storage from './internal/in-memory.js'
 
 import {getBeneficiairesFromPointId} from './beneficiaire.js'
@@ -49,11 +51,11 @@ export async function getPointsFromBeneficiaire(idBeneficiaire) {
 }
 
 export async function getBssById(idBss) {
-  return storage.indexedBss[idBss]
+  return mongo.db.collection('bss').findOne({id_bss: idBss})
 }
 
-export async function getBnpe(id) {
-  return storage.indexedBnpe[id]
+export async function getBnpe(idPoint) {
+  return mongo.db.collection('bnpe').findOne({code_point_prelevement: idPoint})
 }
 
 export async function getCommune(codeInsee) {

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -25,7 +25,7 @@ class Mongo {
     await this.db.collection('volumes_preleves').createIndex({exploitation: 1})
     await this.db.collection('volumes_preleves').createIndex({exploitation: 1, date: 1}, {unique: true})
     await this.db.collection('bss').createIndex({id_bss: 1}, {unique: true})
-    await this.db.collection('bnpe').createIndex({code_point_prelevement: 1}, {unique: true})
+    await this.db.collection('bnpe').createIndex({code_point_prelevement: 1})
   }
 
   disconnect(force) {

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -24,6 +24,8 @@ class Mongo {
     await this.db.collection('dossier_attachments').createIndex({numeroDossier: 1})
     await this.db.collection('volumes_preleves').createIndex({exploitation: 1})
     await this.db.collection('volumes_preleves').createIndex({exploitation: 1, date: 1}, {unique: true})
+    await this.db.collection('bss').createIndex({id_bss: 1}, {unique: true})
+    await this.db.collection('bnpe').createIndex({code_point_prelevement: 1}, {unique: true})
   }
 
   disconnect(force) {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node api.js",
     "update-db": "node scripts/update-db.js",
     "download-csv": "node scripts/download-csv.js",
+    "mongo-import": "node scripts/mongo-import.js",
     "scalingo-postbuild": "yarn download-csv",
     "lint": "xo",
     "test": "ava"

--- a/scripts/mongo-import.js
+++ b/scripts/mongo-import.js
@@ -10,6 +10,13 @@ async function importBSS(bss) {
 
   const collection = mongo.db.collection('bss')
 
+  try {
+    console.log('Nettoyage de la collection...')
+    await collection.deleteMany({})
+  } catch (error) {
+    console.error('Erreur lors du nettoyage de la collection : ' + error)
+  }
+
   const documents = bss.map(b => ({
     id_bss: b.id_bss,
     lien_infoterre: b.lien_infoterre
@@ -31,6 +38,13 @@ async function importBNPE(bnpe) {
   }
 
   const collection = mongo.db.collection('bnpe')
+
+  try {
+    console.log('Nettoyage de la collection...')
+    await collection.deleteMany({})
+  } catch (error) {
+    console.error('Erreur lors du nettoyage de la collection : ' + error)
+  }
 
   const documents = bnpe.map(b => ({
     code_point_prelevement: b.code_point_prelevement,

--- a/scripts/mongo-import.js
+++ b/scripts/mongo-import.js
@@ -10,12 +10,8 @@ async function importBSS(bss) {
 
   const collection = mongo.db.collection('bss')
 
-  try {
-    console.log('Nettoyage de la collection...')
-    await collection.deleteMany({})
-  } catch (error) {
-    console.error('Erreur lors du nettoyage de la collection : ' + error)
-  }
+  console.log('Nettoyage de la collection...')
+  await collection.deleteMany({})
 
   const documents = bss.map(b => ({
     id_bss: b.id_bss,
@@ -39,12 +35,8 @@ async function importBNPE(bnpe) {
 
   const collection = mongo.db.collection('bnpe')
 
-  try {
-    console.log('Nettoyage de la collection...')
-    await collection.deleteMany({})
-  } catch (error) {
-    console.error('Erreur lors du nettoyage de la collection : ' + error)
-  }
+  console.log('Nettoyage de la collection...')
+  await collection.deleteMany({})
 
   const documents = bnpe.map(b => ({
     code_point_prelevement: b.code_point_prelevement,

--- a/scripts/mongo-import.js
+++ b/scripts/mongo-import.js
@@ -1,0 +1,53 @@
+import mongo from '../lib/util/mongo.js'
+import * as storage from '../lib/models/internal/in-memory.js'
+
+async function importBSS(bss) {
+  console.log('Importation des données BSS...')
+  if (!bss || bss.length === 0) {
+    console.error('Le fichier est vide !')
+    return
+  }
+
+  const collection = mongo.db.collection('bss')
+
+  const documents = bss.map(b => ({
+    id_bss: b.id_bss,
+    lien_infoterre: b.lien_infoterre
+  }))
+
+  try {
+    const result = await collection.insertMany(documents)
+    console.log('=> ' + result.insertedCount + ' documents BSS insérés')
+  } catch (error) {
+    console.error('Erreur lors de l’importation : ' + error)
+  }
+}
+
+async function importBNPE(bnpe) {
+  console.log('Importation des données BNPE...')
+  if (!bnpe || bnpe.length === 0) {
+    console.error('Le fichier est vide !')
+    return
+  }
+
+  const collection = mongo.db.collection('bnpe')
+
+  const documents = bnpe.map(b => ({
+    code_point_prelevement: b.code_point_prelevement,
+    uri_ouvrage: b.uri_ouvrage
+  }))
+
+  try {
+    const result = await collection.insertMany(documents)
+    console.log('=> ' + result.insertedCount + ' documents BNPE insérés')
+  } catch (error) {
+    console.error('Erreur lors de l’importation : ' + error)
+  }
+}
+
+await mongo.connect()
+
+await importBSS(storage.bss)
+await importBNPE(storage.bnpe)
+
+await mongo.disconnect()

--- a/scripts/mongo-import.js
+++ b/scripts/mongo-import.js
@@ -22,7 +22,7 @@ async function importBSS(bss) {
     const result = await collection.insertMany(documents)
     console.log('=> ' + result.insertedCount + ' documents BSS insérés')
   } catch (error) {
-    console.error('Erreur lors de l’importation : ' + error)
+    throw new Error('Erreur lors de l’importation : ' + error)
   }
 }
 
@@ -47,7 +47,7 @@ async function importBNPE(bnpe) {
     const result = await collection.insertMany(documents)
     console.log('=> ' + result.insertedCount + ' documents BNPE insérés')
   } catch (error) {
-    console.error('Erreur lors de l’importation : ' + error)
+    throw new Error('Erreur lors de l’importation : ' + error)
   }
 }
 


### PR DESCRIPTION
Cette PR ajoute un script permettant d'importer les données actuellement en mémoire.

- Ajout de deux fonctions pour importer les données BSS et BNPE
- Modification des fonctions qui renvoient les données
- Ajout de l'appel dans `package.json`

