### PR TITLE
Edition des points de prélèvement

### DIFF
--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -153,17 +153,19 @@ export async function updatePointPrelevement(idPoint, payload) {
 
   const enrichedPoint = await enrichPointPrelevement(payload, changes)
 
-  const data = await mongo.db.collection('points_prelevement').findOneAndUpdate(
+  enrichedPoint.updatedAt = new Date()
+
+  const point = await mongo.db.collection('points_prelevement').findOneAndUpdate(
     {id_point: idPoint},
     {$set: enrichedPoint},
     {returnDocument: 'after'}
   )
 
-  if (!data) {
+  if (!point) {
     throw createHttpError(404, 'Ce point de prélèvement est introuvable.')
   }
 
-  return data
+  return point
 }
 
 export async function getPointPrelevement(pointId) {

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -2,7 +2,7 @@ import {chain, minBy, uniq} from 'lodash-es'
 
 import mongo, {ObjectId} from '../util/mongo.js'
 import {isAfter} from 'date-fns'
-import {validateCreation} from '../validation/point-validation.js'
+import {validateCreation, validateChanges} from '../validation/point-validation.js'
 import {nanoid} from 'nanoid'
 import createHttpError from 'http-errors'
 
@@ -142,6 +142,28 @@ export async function createPointPrelevement(payload) {
   await mongo.db.collection('points_prelevement').insertOne(enrichedPoint)
 
   return enrichedPoint
+}
+
+export async function updatePointPrelevement(idPoint, payload) {
+  const changes = validateChanges(payload)
+
+  if (Object.keys(changes).length === 0) {
+    throw createHttpError(400, 'Aucun champ valide trouvé.')
+  }
+
+  const enrichedPoint = await enrichPointPrelevement(payload, changes)
+
+  const data = await mongo.db.collection('points_prelevement').findOneAndUpdate(
+    {id_point: idPoint},
+    {$set: enrichedPoint},
+    {returnDocument: 'after'}
+  )
+
+  if (!data) {
+    throw createHttpError(404, 'Ce point de prélèvement est introuvable.')
+  }
+
+  return data
 }
 
 export async function getPointPrelevement(pointId) {

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -41,13 +41,7 @@ export async function decoratePointPrelevement(point) {
   }
 }
 
-export async function getPointsPrelevement() {
-  return mongo.db.collection('points_prelevement').find().toArray()
-}
-
-export async function createPointPrelevement(payload) {
-  const point = validateCreation(payload)
-
+async function enrichPointPrelevement(payload, point) {
   if (payload.bss) {
     const bss = await mongo.db.collection('bss').findOne({id_bss: payload.bss})
 
@@ -128,14 +122,26 @@ export async function createPointPrelevement(payload) {
     }
   }
 
-  point._id = new ObjectId()
-  point.id_point = nanoid()
-  point.createdAt = new Date()
-  point.updatedAt = new Date()
-
-  await mongo.db.collection('points_prelevement').insertOne(point)
-
   return point
+}
+
+export async function getPointsPrelevement() {
+  return mongo.db.collection('points_prelevement').find().toArray()
+}
+
+export async function createPointPrelevement(payload) {
+  const point = validateCreation(payload)
+
+  const enrichedPoint = await enrichPointPrelevement(payload, point)
+
+  enrichedPoint._id = new ObjectId()
+  enrichedPoint.id_point = nanoid()
+  enrichedPoint.createdAt = new Date()
+  enrichedPoint.updatedAt = new Date()
+
+  await mongo.db.collection('points_prelevement').insertOne(enrichedPoint)
+
+  return enrichedPoint
 }
 
 export async function getPointPrelevement(pointId) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -15,7 +15,8 @@ import {
   getPointPrelevement,
   getPointsFromBeneficiaire,
   getStats,
-  createPointPrelevement
+  createPointPrelevement,
+  updatePointPrelevement
 } from './models/points-prelevement.js'
 
 import {
@@ -106,12 +107,18 @@ async function createRoutes() {
       res.send(decoratedPoint)
     }))
 
-  app.get('/points-prelevement/:id', w(async (req, res) => {
-    const pointPrelevement = await getPointPrelevement(req.params.id)
-    const decoratedPoint = await decoratePointPrelevement(pointPrelevement)
+  app.route('/points-prelevement/:id')
+    .get(w(async (req, res) => {
+      const pointPrelevement = await getPointPrelevement(req.params.id)
+      const decoratedPoint = await decoratePointPrelevement(pointPrelevement)
 
-    res.send(decoratedPoint)
-  }))
+      res.send(decoratedPoint)
+    }))
+    .put(w(async (req, res) => {
+      const point = await updatePointPrelevement(req.params.id, req.body)
+
+      res.send(point)
+    }))
 
   app.get('/points-prelevement/:id/exploitations', w(async (req, res) => {
     const exploitations = await getExploitationsFromPointId(req.params.id)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -94,7 +94,7 @@ async function createRoutes() {
   }))
 
   app.route('/points-prelevement')
-    .get(w(async (req, res) => {
+    .get(w(ensureIsAdmin), w(async (req, res) => {
       const prelevements = await getPointsPrelevement()
       const decoratedPoints = await Promise.all(prelevements.map(p => decoratePointPrelevement(p)))
 
@@ -108,13 +108,13 @@ async function createRoutes() {
     }))
 
   app.route('/points-prelevement/:id')
-    .get(w(async (req, res) => {
+    .get(w(ensureIsAdmin), w(async (req, res) => {
       const pointPrelevement = await getPointPrelevement(req.params.id)
       const decoratedPoint = await decoratePointPrelevement(pointPrelevement)
 
       res.send(decoratedPoint)
     }))
-    .put(w(async (req, res) => {
+    .put(w(ensureIsAdmin), w(async (req, res) => {
       const point = await updatePointPrelevement(req.params.id, req.body)
 
       res.send(point)

--- a/lib/validation/point-validation.js
+++ b/lib/validation/point-validation.js
@@ -38,66 +38,61 @@ function validateGeom(geom, helpers) {
   return geom
 }
 
+function addStringMessages(field, fieldName) {
+  return field.messages({
+    'string.base': `Le champ "${fieldName}" doit être une chaine de caractères.`,
+    'string.empty': `Le champ "${fieldName}" ne peut pas être vide.`
+  })
+}
+
+const POINT_FIELDS = {
+  nom: Joi.string().trim().min(3).max(200),
+  autresNoms: Joi.string().trim().min(3).max(500),
+  code_aiot: Joi.string().trim().min(3).max(200),
+  type_milieu: Joi.custom(validateTypeMilieu),
+  profondeur: Joi.number().positive(),
+  zre: Joi.bool(),
+  reservoir_biologique: Joi.bool(),
+  cours_eau: Joi.string().trim().min(3).max(200),
+  detail_localisation: Joi.string().trim().min(3).max(200),
+  geom: Joi.custom(validateGeom),
+  precision_geom: Joi.custom(validatePrecisionGeom),
+  remarque: Joi.string().trim().min(3).max(500),
+  bss: Joi.string().trim().length(10),
+  bnpe: Joi.string().trim().length(18),
+  meso: Joi.string().trim().length(7),
+  meContinentalesBv: Joi.string().trim().min(6).max(7),
+  bvBdCarthage: Joi.string().trim().length(8),
+  commune: Joi.string().trim().min(3).max(100)
+}
+
 const pointSchemaCreation = Joi.object().keys({
-  nom: Joi.string().required().messages({
-    'string.base': 'Le nom doit être une chaine de caractères.',
-    'string.empty': 'Le nom ne peut pas être vide.'
-  }),
-  autresNoms: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "autres_noms" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "autres_noms" ne peut pas être vide.'
-  }),
-  code_aiot: Joi.string().allow(null).messages({
-    'string.base': 'Le code AIOT doit être une chaine de caractères.',
-    'string.empty': 'Le code AIOT ne peut pas être vide.'
-  }),
-  type_milieu: Joi.custom(validateTypeMilieu).required().messages({
+  nom: addStringMessages(POINT_FIELDS.nom.required(), 'nom'),
+  autresNoms: addStringMessages(POINT_FIELDS.autresNoms.allow(null), 'autresNoms'),
+  code_aiot: addStringMessages(POINT_FIELDS.code_aiot.allow(null), 'code_aiot'),
+  type_milieu: POINT_FIELDS.type_milieu.required().messages({
     'any.required': 'Le type de milieu est obligatoire.'
   }),
-  profondeur: Joi.number().positive().allow(null).messages({
+  profondeur: POINT_FIELDS.profondeur.allow(null).messages({
     'number.base': 'La profondeur doit être un nombre.'
   }),
-  zre: Joi.bool().allow(null),
-  reservoir_biologique: Joi.bool().allow(null),
-  cours_eau: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "cours_eau" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "cours_eau" ne peux pas être vide.'
-  }),
-  detail_localisation: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "detail_localisation" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "detail_localisation" ne peux pas être vide.'
-  }),
-  geom: Joi.custom(validateGeom).required().messages({
+  zre: POINT_FIELDS.zre.allow(null),
+  reservoir_biologique: POINT_FIELDS.reservoir_biologique.allow(null),
+  cours_eau: addStringMessages(POINT_FIELDS.cours_eau.allow(null), 'cours_eau'),
+  detail_localisation: addStringMessages(POINT_FIELDS.detail_localisation.allow(null), 'detail_localisation'),
+  geom: POINT_FIELDS.geom.required().messages({
     'any.required': 'La géométrie est obligatoire.'
   }),
-  precision_geom: Joi.custom(validatePrecisionGeom).required().messages({
+  precision_geom: POINT_FIELDS.precision_geom.required().messages({
     'any.required': 'La précision géométrique est obligatoire.'
   }),
-  remarque: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "remarque" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "remarque" ne peut pas être vide.'
-  }),
-  bss: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "bss" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "bss" ne peut pas être vide.'
-  }),
-  bnpe: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "bnpe" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "bnpe" ne peut pas être vide.'
-  }),
-  meso: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "meso" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "meso" ne peut pas être vide.'
-  }),
-  meContinentalesBv: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "meContinentalesBv" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "meContinentalesBv" ne peut pas être vide.'
-  }),
-  bvBdCarthage: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "bvBdCarthage" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "bvBdCarthage" ne peut pas être vide.'
-  }),
-  commune: Joi.string().required().messages({
+  remarque: addStringMessages(POINT_FIELDS.remarque.allow(null), 'remarque'),
+  bss: addStringMessages(POINT_FIELDS.bss.allow(null), 'bss'),
+  bnpe: addStringMessages(POINT_FIELDS.bnpe.allow(null), 'bnpe'),
+  meso: addStringMessages(POINT_FIELDS.meso.allow(null), 'meso'),
+  meContinentalesBv: addStringMessages(POINT_FIELDS.meContinentalesBv.allow(null), 'meContinentalesBv'),
+  bvBdCarthage: addStringMessages(POINT_FIELDS.bvBdCarthage.allow(null), 'bvBdCarthage'),
+  commune: POINT_FIELDS.commune.required().messages({
     'string.base': 'Le champ "commune" doit être une chaine de caractères.',
     'any.required': 'La commune est obligatoire.'
   })
@@ -106,59 +101,24 @@ const pointSchemaCreation = Joi.object().keys({
 })
 
 const pointSchemaEdition = Joi.object().keys({
-  nom: Joi.string().messages({
-    'string.base': 'Le nom doit être une chaine de caractères.',
-    'string.empty': 'Le nom ne peut pas être vide.'
-  }),
-  autresNoms: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "autres_noms" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "autres_noms" ne peut pas être vide.'
-  }),
-  code_aiot: Joi.string().allow(null).messages({
-    'string.base': 'Le code AIOT doit être une chaine de caractères.',
-    'string.empty': 'Le code AIOT ne peut pas être vide.'
-  }),
-  type_milieu: Joi.custom(validateTypeMilieu).allow(null),
-  profondeur: Joi.number().positive().allow(null).messages({
-    'number.base': 'La profondeur doit être un nombre.'
-  }),
-  zre: Joi.bool().allow(null),
-  reservoir_biologique: Joi.bool().allow(null),
-  cours_eau: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "cours_eau" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "cours_eau" ne peux pas être vide.'
-  }),
-  detail_localisation: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "detail_localisation" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "detail_localisation" ne peux pas être vide.'
-  }),
-  geom: Joi.custom(validateGeom),
-  precision_geom: Joi.custom(validatePrecisionGeom).allow(null),
-  remarque: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "remarque" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "remarque" ne peut pas être vide.'
-  }),
-  bss: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "bss" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "bss" ne peut pas être vide.'
-  }),
-  bnpe: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "bnpe" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "bnpe" ne peut pas être vide.'
-  }),
-  meso: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "meso" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "meso" ne peut pas être vide.'
-  }),
-  meContinentalesBv: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "meContinentalesBv" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "meContinentalesBv" ne peut pas être vide.'
-  }),
-  bvBdCarthage: Joi.string().allow(null).messages({
-    'string.base': 'Le champ "bvBdCarthage" doit être une chaine de caractères.',
-    'string.empty': 'Le champ "bvBdCarthage" ne peut pas être vide.'
-  }),
-  commune: Joi.string().messages({
+  nom: addStringMessages(POINT_FIELDS.nom, 'nom'),
+  autresNoms: addStringMessages(POINT_FIELDS.autresNoms.allow(null), 'autresNoms'),
+  code_aiot: addStringMessages(POINT_FIELDS.code_aiot.allow(null), 'code_aiot'),
+  type_milieu: POINT_FIELDS.type_milieu.allow(null),
+  profondeur: POINT_FIELDS.profondeur.allow(null),
+  zre: POINT_FIELDS.zre.allow(null),
+  reservoir_biologique: POINT_FIELDS.reservoir_biologique.allow(null),
+  cours_eau: addStringMessages(POINT_FIELDS.cours_eau.allow(null), 'cours_eau'),
+  detail_localisation: addStringMessages(POINT_FIELDS.detail_localisation.allow(null), 'detail_localisation'),
+  geom: POINT_FIELDS.geom,
+  precision_geom: POINT_FIELDS.precision_geom.allow(null),
+  remarque: addStringMessages(POINT_FIELDS.remarque.allow(null), 'remarque'),
+  bss: addStringMessages(POINT_FIELDS.bss.allow(null), 'bss'),
+  bnpe: addStringMessages(POINT_FIELDS.bnpe.allow(null), 'bnpe'),
+  meso: addStringMessages(POINT_FIELDS.meso.allow(null), 'meso'),
+  meContinentalesBv: addStringMessages(POINT_FIELDS.meContinentalesBv.allow(null), 'meContinentalesBv'),
+  bvBdCarthage: addStringMessages(POINT_FIELDS.bvBdCarthage.allow(null), 'bvBdCarthage'),
+  commune: POINT_FIELDS.commune.messages({
     'string.base': 'Le champ "commune" doit être une chaine de caractères.'
   })
 }).messages({

--- a/lib/validation/point-validation.js
+++ b/lib/validation/point-validation.js
@@ -105,8 +105,72 @@ const pointSchemaCreation = Joi.object().keys({
   'object.unknown': 'Une clé de l’objet est invalide'
 })
 
+const pointSchemaEdition = Joi.object().keys({
+  nom: Joi.string().messages({
+    'string.base': 'Le nom doit être une chaine de caractères.',
+    'string.empty': 'Le nom ne peut pas être vide.'
+  }),
+  autresNoms: Joi.string().allow(null).messages({
+    'string.base': 'Le champ "autres_noms" doit être une chaine de caractères.',
+    'string.empty': 'Le champ "autres_noms" ne peut pas être vide.'
+  }),
+  code_aiot: Joi.string().allow(null).messages({
+    'string.base': 'Le code AIOT doit être une chaine de caractères.',
+    'string.empty': 'Le code AIOT ne peut pas être vide.'
+  }),
+  type_milieu: Joi.custom(validateTypeMilieu).allow(null),
+  profondeur: Joi.number().positive().allow(null).messages({
+    'number.base': 'La profondeur doit être un nombre.'
+  }),
+  zre: Joi.bool().allow(null),
+  reservoir_biologique: Joi.bool().allow(null),
+  cours_eau: Joi.string().allow(null).messages({
+    'string.base': 'Le champ "cours_eau" doit être une chaine de caractères.',
+    'string.empty': 'Le champ "cours_eau" ne peux pas être vide.'
+  }),
+  detail_localisation: Joi.string().allow(null).messages({
+    'string.base': 'Le champ "detail_localisation" doit être une chaine de caractères.',
+    'string.empty': 'Le champ "detail_localisation" ne peux pas être vide.'
+  }),
+  geom: Joi.custom(validateGeom),
+  precision_geom: Joi.custom(validatePrecisionGeom).allow(null),
+  remarque: Joi.string().allow(null).messages({
+    'string.base': 'Le champ "remarque" doit être une chaine de caractères.',
+    'string.empty': 'Le champ "remarque" ne peut pas être vide.'
+  }),
+  bss: Joi.string().allow(null).messages({
+    'string.base': 'Le champ "bss" doit être une chaine de caractères.',
+    'string.empty': 'Le champ "bss" ne peut pas être vide.'
+  }),
+  bnpe: Joi.string().allow(null).messages({
+    'string.base': 'Le champ "bnpe" doit être une chaine de caractères.',
+    'string.empty': 'Le champ "bnpe" ne peut pas être vide.'
+  }),
+  meso: Joi.string().allow(null).messages({
+    'string.base': 'Le champ "meso" doit être une chaine de caractères.',
+    'string.empty': 'Le champ "meso" ne peut pas être vide.'
+  }),
+  meContinentalesBv: Joi.string().allow(null).messages({
+    'string.base': 'Le champ "meContinentalesBv" doit être une chaine de caractères.',
+    'string.empty': 'Le champ "meContinentalesBv" ne peut pas être vide.'
+  }),
+  bvBdCarthage: Joi.string().allow(null).messages({
+    'string.base': 'Le champ "bvBdCarthage" doit être une chaine de caractères.',
+    'string.empty': 'Le champ "bvBdCarthage" ne peut pas être vide.'
+  }),
+  commune: Joi.string().messages({
+    'string.base': 'Le champ "commune" doit être une chaine de caractères.'
+  })
+}).messages({
+  'object.unknown': 'Une clé de l’objet est invalide'
+})
+
 function validateCreation(point) {
   return validatePayload(point, pointSchemaCreation)
 }
 
-export {validateCreation}
+function validateChanges(changes) {
+  return validatePayload(changes, pointSchemaEdition)
+}
+
+export {validateCreation, validateChanges}

--- a/scripts/mongo-import.js
+++ b/scripts/mongo-import.js
@@ -70,6 +70,9 @@ async function preparePoint(pointId) {
 
   delete point.insee_com
 
+  point.createdAt = new Date()
+  point.updatedAt = new Date()
+
   return point
 }
 


### PR DESCRIPTION
Ces modifications ajoutent la possibilité d'éditer un point de prélèvement.

- Réutilisation de la fonction pour enrichir les points
- Création du schéma de validation lors de l'édition
- Ajout de la fonction `updatePointPrelevement`
- Ajout de la route pour la mise à jour d'un point
- Ajout de `ensureIsAdmin` pour protéger la route

> [!warning]
> Il faut modifier le front avant de merger cette PR
> **Le front appel la route GET sans jeton.**