### PR TITLE
Opérations CRUD pour les exploitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,12 @@ yarn lint
 | `/points-prelevement/:id`| **GET** * | *Retourne le point de prélèvement* |
 | `/points-prelevement/:id`| **PUT** * | *Modifie le point de prélèvement* |
 | `/points-prelevement/:id`| **DELETE** * | *Supprime le point de prélèvement* |
-| `/points-prelevement/:id/exploitations`| **GET** | *Retourne la liste des exploitations du point* |
-| `/exploitations:id`| **GET** | *Retourne l'exploitation* |
-| `/exploitations/:id/volumes-preleves`| **GET** | *Retourne les volumes prélevés de l'exploitations* |
+| `/points-prelevement/:id/exploitations`| **GET** * | *Retourne la liste des exploitations du point* |
+| `/exploitations`| **POST** * | *Crée une exploitation* |
+| `/exploitations:id`| **GET** * | *Retourne l'exploitation* |
+| `/exploitations:id`| **PUT** * | *Modifie l'exploitation* |
+| `/exploitations:id`| **DELETE** * | *Supprime l'exploitation* |
+| `/exploitations/:id/volumes-preleves`| **GET** * | *Retourne les volumes prélevés de l'exploitations* |
 | `/beneficiaires`| **GET** | *Retourne la liste des préleveurs* |
 | `/beneficiaires/:id`| **GET** | *Retourne le préleveur* |
 | `/beneficiaires/:id/points-prelevement`| **GET** | *Retourne les points exploités par le préleveur* |
@@ -104,6 +107,20 @@ yarn lint
 | `meContinentalesBv` | string | non |
 | `bvBdCarthage` | string | non |
 | `commune` | string | oui |
+
+### Objet `exploitation` :
+
+| Propriété | Type | Obligatoire |
+|-----------|------|-------------|
+| `date_debut` | string | oui |
+| `statut` | string | oui |
+| `remarque` | string | non |
+| `id_point` | string | oui |
+| `id_beneficiaire` | string | oui |
+| `usages` | array | oui |
+| `regles` | array | non |
+| `documents` | array | non |
+| `modalites` | array | non |
 
 ---
 

--- a/lib/models/exploitation.js
+++ b/lib/models/exploitation.js
@@ -1,12 +1,93 @@
-import mongo from '../util/mongo.js'
+import {nanoid} from 'nanoid'
+import mongo, {ObjectId} from '../util/mongo.js'
+import {validateChanges, validateCreation} from '../validation/exploitation-validation.js'
 import * as storage from './internal/in-memory.js'
+import createHttpError from 'http-errors'
 
 export async function getExploitationsFromPointId(idPoint) {
   return mongo.db.collection('exploitations').find({id_point: idPoint}).toArray()
 }
 
 export async function getExploitation(idExploitation) {
-  return mongo.db.collection('exploitations').findOne({id_exploitation: idExploitation})
+  return mongo.db.collection('exploitations').findOne(
+    {id_exploitation: idExploitation, deletedAt: {$exists: false}}
+  )
+}
+
+export async function createExploitation(payload) {
+  const exploitation = validateCreation(payload)
+
+  const point = await mongo.db.collection('points_prelevement').findOne({id_point: payload.id_point})
+
+  if (!point) {
+    throw createHttpError(400, 'Ce point de prélèvement est introuvable.')
+  }
+
+  const preleveur = await mongo.db.collection('preleveurs').findOne({id_beneficiaire: payload.id_beneficiaire})
+
+  if (!preleveur) {
+    throw createHttpError(400, 'Ce préleveur est introuvable.')
+  }
+
+  if (exploitation.documents.length > 1) {
+    for (const document of exploitation.documents) {
+      document.id_document = nanoid()
+    }
+  }
+
+  if (exploitation.regles.length > 1) {
+    for (const regle of exploitation.regles) {
+      regle.id_regle = nanoid()
+    }
+  }
+
+  if (exploitation.modalites.length > 1) {
+    for (const modalite of exploitation.modalites) {
+      modalite.id_modalite = nanoid()
+    }
+  }
+
+  exploitation._id = new ObjectId()
+  exploitation.id_exploitation = nanoid()
+  exploitation.createdAt = new Date()
+  exploitation.updatedAt = new Date()
+
+  await mongo.db.collection('exploitations').insertOne(exploitation)
+
+  return exploitation
+}
+
+export async function updateExploitation(idExploitation, payload) {
+  const changes = validateChanges(payload)
+
+  if (Object.keys(changes).length === 0) {
+    throw createHttpError(400, 'Aucun champ valide trouvé.')
+  }
+
+  changes.updatedAt = new Date()
+
+  const exploitation = await mongo.db.collection('exploitations').findOneAndUpdate(
+    {id_exploitation: idExploitation, deletedAt: {$exists: false}},
+    {$set: changes},
+    {returnDocument: 'after'}
+  )
+
+  if (!exploitation) {
+    throw createHttpError(404, 'Cette exploitation est introuvable.')
+  }
+
+  return exploitation
+}
+
+export async function deleteExploitation(exploitationId) {
+  return mongo.db.collection('exploitations').findOneAndUpdate(
+    {id_exploitation: exploitationId, deletedAt: {$exists: false}},
+    {$set: {
+      deletedAt: new Date(),
+      updatedAt: new Date()
+    }},
+    {returnDocument: 'after'}
+  )
 }
 
 export async function getDocumentFromExploitationId(idExploitation) {

--- a/lib/models/exploitation.js
+++ b/lib/models/exploitation.js
@@ -5,7 +5,9 @@ import * as storage from './internal/in-memory.js'
 import createHttpError from 'http-errors'
 
 export async function getExploitationsFromPointId(idPoint) {
-  return mongo.db.collection('exploitations').find({id_point: idPoint}).toArray()
+  return mongo.db.collection('exploitations').find(
+    {id_point: idPoint, deletedAt: {$exists: false}}
+  ).toArray()
 }
 
 export async function getExploitation(idExploitation) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -159,7 +159,7 @@ async function createRoutes() {
       res.send(deletedExploitation)
     }))
 
-  app.get('/exploitations/:id/volumes-preleves', w(async (req, res) => {
+  app.get('/exploitations/:id/volumes-preleves', w(ensureIsAdmin), w(async (req, res) => {
     const volumesPreleves = await getVolumesPreleves(req.params.id)
 
     const exploitation = await mongo.db.collection('exploitations').findOne({id_exploitation: req.params.id})

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -129,7 +129,7 @@ async function createRoutes() {
       res.send(deletedPoint)
     }))
 
-  app.get('/points-prelevement/:id/exploitations', w(async (req, res) => {
+  app.get('/points-prelevement/:id/exploitations', w(ensureIsAdmin), w(async (req, res) => {
     const exploitations = await getExploitationsFromPointId(req.params.id)
 
     res.send(exploitations)

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -28,7 +28,10 @@ import {
 
 import {
   getExploitationsFromPointId,
-  getExploitation
+  getExploitation,
+  createExploitation,
+  updateExploitation,
+  deleteExploitation
 } from './models/exploitation.js'
 
 import {
@@ -132,11 +135,29 @@ async function createRoutes() {
     res.send(exploitations)
   }))
 
-  app.get('/exploitations/:id', w(async (req, res) => {
-    const exploitation = await getExploitation(req.params.id)
+  app.route('/exploitations')
+    .post(w(ensureIsAdmin), w(async (req, res) => {
+      const exploitation = await createExploitation(req.body)
 
-    res.send(exploitation)
-  }))
+      res.send(exploitation)
+    }))
+
+  app.route('/exploitations/:id')
+    .get(w(ensureIsAdmin), w(async (req, res) => {
+      const exploitation = await getExploitation(req.params.id)
+
+      res.send(exploitation)
+    }))
+    .put(w(ensureIsAdmin), w(async (req, res) => {
+      const exploitation = await updateExploitation(req.params.id, req.body)
+
+      res.send(exploitation)
+    }))
+    .delete(w(ensureIsAdmin), w(async (req, res) => {
+      const deletedExploitation = await deleteExploitation(req.params.id)
+
+      res.send(deletedExploitation)
+    }))
 
   app.get('/exploitations/:id/volumes-preleves', w(async (req, res) => {
     const volumesPreleves = await getVolumesPreleves(req.params.id)

--- a/lib/validation/exploitation-validation.js
+++ b/lib/validation/exploitation-validation.js
@@ -1,0 +1,206 @@
+import Joi from 'joi'
+import {validatePayload} from '../util/payload.js'
+import {contraintes, frequences, natures, parametres, statutsExploitation, unites, usages} from '../nomenclature.js'
+
+function validateDate(date, helpers) {
+  if (!date || typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return helpers.message('La date est invalide.')
+  }
+
+  const parsedDate = new Date(date)
+
+  if (parsedDate.toString() === 'Invalid Date') {
+    return helpers.message('La date est invalide.')
+  }
+
+  return date
+}
+
+function validateParametre(parametre, helpers) {
+  if (!Object.values(parametres).includes(parametre)) {
+    return helpers.message('Le paramètre est invalide.')
+  }
+
+  return parametre
+}
+
+function validateUnite(unite, helpers) {
+  if (!Object.values(unites).includes(unite)) {
+    return helpers.message('L’unité est invalide.')
+  }
+
+  return unite
+}
+
+function validateContrainte(contrainte, helpers) {
+  if (!Object.values(contraintes).includes(contrainte)) {
+    return helpers.message('La contrainte est invalide.')
+  }
+
+  return contrainte
+}
+
+function validateFrequence(frequence, helpers) {
+  if (!Object.values(frequences).includes(frequence)) {
+    return helpers.message('Cette fréquence est invalide.')
+  }
+
+  return frequence
+}
+
+function validateNature(nature, helpers) {
+  if (!Object.values(natures).includes(nature)) {
+    return helpers.message('Cette nature est invalide.')
+  }
+}
+
+function validateStatut(statut, helpers) {
+  if (!Object.values(statutsExploitation).includes(statut)) {
+    return helpers.message('Ce statut est invalide.')
+  }
+
+  return statut
+}
+
+function validateUsage(usage, helpers) {
+  if (!Object.values(usages).includes(usage)) {
+    return helpers.message('Cet usage est invalide.')
+  }
+
+  return usage
+}
+
+function addStringMessages(field, fieldName) {
+  return field.messages({
+    'string.base': `Le champ "${fieldName}" doit être une chaine de caractères.`,
+    'string.empty': `Le champ "${fieldName}" ne peut pas être vide.`
+  })
+}
+
+const documentSchema = Joi.object().keys({
+  nom_fichier: addStringMessages(Joi.string().trim().min(3).max(200).required(), 'nom_fichier'),
+  reference: addStringMessages(Joi.string().trim().min(3).max(200).allow(null), 'reference'),
+  nature: Joi.custom(validateNature).allow(null),
+  date_signature: Joi.custom(validateDate).required().messages({
+    'any.required': 'La date de signature est obligatoire.'
+  }),
+  date_fin_validite: Joi.custom(validateDate).allow(null),
+  date_ajout: Joi.custom(validateDate).required().messages({
+    'any.required': 'La date d’ajout est obligatoire.'
+  }),
+  remarque: addStringMessages(Joi.string().trim().min(3).max(500).allow(null), 'remarque')
+})
+
+const regleSchema = Joi.object().keys({
+  parametre: Joi.custom(validateParametre).required().messages({
+    'any.required': 'Le paramètre est obligatoire'
+  }),
+  unite: Joi.custom(validateUnite).required().messages({
+    'any.required': 'L’unité est obligatoire.'
+  }),
+  valeur: Joi.number().required().messages({
+    'any.required': 'La valeur est obligatoire.',
+    'number.base': 'La valeur doit être un nombre.'
+  }),
+  contrainte: Joi.custom(validateContrainte),
+  debut_validite: Joi.custom(validateDate).required().messages({
+    'any.required': 'La date de début de validité est obligatoire.'
+  }),
+  fin_validite: Joi.custom(validateDate).allow(null),
+  debut_periode: Joi.custom(validateDate).allow(null),
+  fin_periode: Joi.custom(validateDate).allow(null),
+  remarque: addStringMessages(Joi.string().trim().min(3).max(500).allow(null), 'remarque'),
+  id_document: Joi.string().trim().max(200).required().messages({
+    'any.required': 'L’id du document est obligatoire.',
+    'string.base': 'L’id du document doit être une chaine de caractères.'
+  })
+})
+
+const modaliteSchema = Joi.object().keys({
+  freq_volume_preleve: Joi.custom(validateFrequence).allow(null),
+  freq_debit_preleve: Joi.custom(validateFrequence).allow(null),
+  freq_debit_reserve: Joi.custom(validateFrequence).allow(null),
+  freq_conductivite: Joi.custom(validateFrequence).allow(null),
+  freq_temperature: Joi.custom(validateFrequence).allow(null),
+  freq_niveau_eau: Joi.custom(validateFrequence).allow(null),
+  freq_ph: Joi.custom(validateFrequence).allow(null),
+  freq_nitrates: Joi.custom(validateFrequence).allow(null),
+  freq_sulfates: Joi.custom(validateFrequence).allow(null),
+  remarque: Joi.string().allow(null).messages({
+    'string.base': 'La remarque doit être une chaine de caractères.',
+    'string.empty': 'La remarque ne peut pas être vide.'
+  })
+})
+
+const EXPLOITATION_FIELDS = {
+  date_debut: Joi.custom(validateDate),
+  date_fin: Joi.custom(validateDate),
+  statut: Joi.custom(validateStatut),
+  raison_abandon: Joi.string().trim().min(3).max(500),
+  remarque: Joi.string().trim().min(3).max(500),
+  id_point: Joi.string().trim().min(1).max(200),
+  id_beneficiaire: Joi.string().trim().min(1).max(200),
+  usages: Joi.array().min(1).items(Joi.string().custom(validateUsage)),
+  regles: Joi.array().items(regleSchema),
+  documents: Joi.array().items(documentSchema),
+  modalites: Joi.array().items(modaliteSchema)
+}
+
+const exploitationSchemaCreation = Joi.object().keys({
+  date_debut: EXPLOITATION_FIELDS.date_debut.required().messages({
+    'any.required': 'Une date de début est obligatoire.'
+  }),
+  date_fin: EXPLOITATION_FIELDS.date_fin.allow(null),
+  statut: EXPLOITATION_FIELDS.statut.required().messages({
+    'any.required': 'Le statut est obligatoire.'
+  }),
+  raison_abandon: addStringMessages(EXPLOITATION_FIELDS.raison_abandon.allow(null), 'raison_abandon'),
+  remarque: addStringMessages(EXPLOITATION_FIELDS.remarque.allow(null), 'remarque'),
+  id_point: EXPLOITATION_FIELDS.id_point.required().messages({
+    'any.required': 'L’id du point est obligatoire.'
+  }),
+  id_beneficiaire: EXPLOITATION_FIELDS.id_beneficiaire.required().messages({
+    'any.required': 'L’id du préleveur est obligatoire.'
+  }),
+  usages: EXPLOITATION_FIELDS.usages.required().messages({
+    'array.base': 'Les usages doivent  être dans un tableau',
+    'string.base': 'Les usages doivent être des chaines de caractères.',
+    'any.required': 'Au moins un usage est obligatoire.'
+  }),
+  regles: EXPLOITATION_FIELDS.regles.required().messages({
+    'array.base': 'Les règles doivent être dans un tableau.',
+    'any.required': 'Le tableau règles sont obligatoires.'
+  }),
+  documents: EXPLOITATION_FIELDS.documents.required().messages({
+    'array.base': 'Les documents doivent être dans un tableau.',
+    'any.required': 'Le tableau documents sont obligatoires.'
+  }),
+  modalites: EXPLOITATION_FIELDS.modalites.required().messages({
+    'array.base': 'Les modalités doivent être dans un tableau.',
+    'any.required': 'Le tableau modalités est obligatoire.'
+  })
+})
+
+const exploitationSchemaEdition = Joi.object().keys({
+  date_debut: EXPLOITATION_FIELDS.date_debut,
+  date_fin: EXPLOITATION_FIELDS.date_fin.allow(null),
+  statut: EXPLOITATION_FIELDS.statut,
+  raison_abandon: addStringMessages(EXPLOITATION_FIELDS.raison_abandon.allow(null), 'raison_abandon'),
+  remarque: addStringMessages(EXPLOITATION_FIELDS.remarque.allow(null), 'remarque'),
+  id_point: EXPLOITATION_FIELDS.id_point,
+  id_beneficiaire: EXPLOITATION_FIELDS.id_beneficiaire,
+  usages: EXPLOITATION_FIELDS.usages,
+  regles: EXPLOITATION_FIELDS.regles,
+  documents: EXPLOITATION_FIELDS.documents,
+  modalites: EXPLOITATION_FIELDS.modalites
+})
+
+function validateCreation(exploitation) {
+  return validatePayload(exploitation, exploitationSchemaCreation)
+}
+
+function validateChanges(changes) {
+  return validatePayload(changes, exploitationSchemaEdition)
+}
+
+export {validateCreation, validateChanges}


### PR DESCRIPTION
Cette PR ajoute des routes permettant de créer, modifier et supprimer des exploitations.

- Fonctions de validation pour la création / mise à jour
- Fonctions pour créer / mettre à jour / supprimer une exploitation
- Ajout du `ensureIsAdmin` pour protéger les routes
- Mise à jour du README

> [!warning]
> *Il faut mettre à jour le front pour les routes qui sont maintenant protégées*