### PR TITLE
Authentification par territoire

### DIFF
--- a/lib/models/exploitation.js
+++ b/lib/models/exploitation.js
@@ -4,19 +4,19 @@ import {validateChanges, validateCreation} from '../validation/exploitation-vali
 import * as storage from './internal/in-memory.js'
 import createHttpError from 'http-errors'
 
-export async function getExploitationsFromPointId(idPoint) {
+export async function getExploitationsFromPointId(idPoint, codeTerritoire) {
   return mongo.db.collection('exploitations').find(
-    {id_point: idPoint, deletedAt: {$exists: false}}
+    {id_point: idPoint, territoire: codeTerritoire, deletedAt: {$exists: false}}
   ).toArray()
 }
 
-export async function getExploitation(idExploitation) {
+export async function getExploitation(idExploitation, codeTerritoire) {
   return mongo.db.collection('exploitations').findOne(
-    {id_exploitation: idExploitation, deletedAt: {$exists: false}}
+    {id_exploitation: idExploitation, territoire: codeTerritoire, deletedAt: {$exists: false}}
   )
 }
 
-export async function createExploitation(payload) {
+export async function createExploitation(payload, codeTerritoire) {
   const exploitation = validateCreation(payload)
 
   const point = await mongo.db.collection('points_prelevement').findOne({id_point: payload.id_point})
@@ -51,6 +51,7 @@ export async function createExploitation(payload) {
 
   exploitation._id = new ObjectId()
   exploitation.id_exploitation = nanoid()
+  exploitation.territoire = codeTerritoire
   exploitation.createdAt = new Date()
   exploitation.updatedAt = new Date()
 
@@ -59,7 +60,7 @@ export async function createExploitation(payload) {
   return exploitation
 }
 
-export async function updateExploitation(idExploitation, payload) {
+export async function updateExploitation(idExploitation, codeTerritoire, payload) {
   const changes = validateChanges(payload)
 
   if (Object.keys(changes).length === 0) {
@@ -69,7 +70,7 @@ export async function updateExploitation(idExploitation, payload) {
   changes.updatedAt = new Date()
 
   const exploitation = await mongo.db.collection('exploitations').findOneAndUpdate(
-    {id_exploitation: idExploitation, deletedAt: {$exists: false}},
+    {id_exploitation: idExploitation, territoire: codeTerritoire, deletedAt: {$exists: false}},
     {$set: changes},
     {returnDocument: 'after'}
   )
@@ -81,9 +82,9 @@ export async function updateExploitation(idExploitation, payload) {
   return exploitation
 }
 
-export async function deleteExploitation(exploitationId) {
+export async function deleteExploitation(exploitationId, codeTerritoire) {
   return mongo.db.collection('exploitations').findOneAndUpdate(
-    {id_exploitation: exploitationId, deletedAt: {$exists: false}},
+    {id_exploitation: exploitationId, territoire: codeTerritoire, deletedAt: {$exists: false}},
     {$set: {
       deletedAt: new Date(),
       updatedAt: new Date()

--- a/lib/models/points-prelevement.js
+++ b/lib/models/points-prelevement.js
@@ -125,8 +125,10 @@ async function enrichPointPrelevement(payload, point) {
   return point
 }
 
-export async function getPointsPrelevement() {
-  return mongo.db.collection('points_prelevement').find({deletedAt: {$exists: false}}).toArray()
+export async function getPointsPrelevement(codeTerritoire) {
+  return mongo.db.collection('points_prelevement').find(
+    {deletedAt: {$exists: false}, territoire: codeTerritoire}
+  ).toArray()
 }
 
 export async function getPointsPrelevementFromTerritoire(codeTerritoire) {
@@ -135,13 +137,14 @@ export async function getPointsPrelevementFromTerritoire(codeTerritoire) {
   ).toArray()
 }
 
-export async function createPointPrelevement(payload) {
+export async function createPointPrelevement(payload, codeTerritoire) {
   const point = validateCreation(payload)
 
   const enrichedPoint = await enrichPointPrelevement(payload, point)
 
   enrichedPoint._id = new ObjectId()
   enrichedPoint.id_point = nanoid()
+  enrichedPoint.territoire = codeTerritoire
   enrichedPoint.createdAt = new Date()
   enrichedPoint.updatedAt = new Date()
 
@@ -150,7 +153,7 @@ export async function createPointPrelevement(payload) {
   return enrichedPoint
 }
 
-export async function updatePointPrelevement(idPoint, payload) {
+export async function updatePointPrelevement(idPoint, codeTerritoire, payload) {
   const changes = validateChanges(payload)
 
   if (Object.keys(changes).length === 0) {
@@ -162,7 +165,7 @@ export async function updatePointPrelevement(idPoint, payload) {
   enrichedPoint.updatedAt = new Date()
 
   const point = await mongo.db.collection('points_prelevement').findOneAndUpdate(
-    {id_point: idPoint, deletedAt: {$exists: false}},
+    {id_point: idPoint, territoire: codeTerritoire, deletedAt: {$exists: false}},
     {$set: enrichedPoint},
     {returnDocument: 'after'}
   )
@@ -174,15 +177,20 @@ export async function updatePointPrelevement(idPoint, payload) {
   return point
 }
 
-export async function getPointPrelevement(pointId) {
+export async function getPointPrelevement(pointId, codeTerritoire) {
   return mongo.db.collection('points_prelevement').findOne(
-    {id_point: pointId, deletedAt: {$exists: false}}
+    {id_point: pointId, territoire: codeTerritoire, deletedAt: {$exists: false}}
   )
 }
 
-export async function deletePointPrelevement(pointId) {
+export async function deletePointPrelevement(pointId, codeTerritoire) {
   const activeExploitation = await mongo.db.collection('exploitations').findOne(
-    {id_point: pointId, statut: 'En activité'}
+    {
+      id_point: pointId,
+      statut: 'En activité',
+      deletedAt: {$exists: false},
+      territoire: codeTerritoire
+    }
   )
 
   if (activeExploitation) {
@@ -190,7 +198,11 @@ export async function deletePointPrelevement(pointId) {
   }
 
   return mongo.db.collection('points_prelevement').findOneAndUpdate(
-    {id_point: pointId, deletedAt: {$exists: false}},
+    {
+      id_point: pointId,
+      territoire: codeTerritoire,
+      deletedAt: {$exists: false}
+    },
     {$set: {
       deletedAt: new Date(),
       updatedAt: new Date()

--- a/lib/models/preleveur.js
+++ b/lib/models/preleveur.js
@@ -20,14 +20,16 @@ export async function decoratePreleveur(preleveur) {
   }
 }
 
-export async function getPreleveur(idPreleveur) {
+export async function getPreleveur(idPreleveur, codeTerritoire) {
   return mongo.db.collection('preleveurs').findOne(
-    {id_preleveur: idPreleveur, deletedAt: {$exists: false}}
+    {id_preleveur: idPreleveur, territoire: codeTerritoire, deletedAt: {$exists: false}}
   )
 }
 
-export async function getPreleveurs() {
-  return mongo.db.collection('preleveurs').find({deletedAt: {$exists: false}}).toArray()
+export async function getPreleveurs(codeTerritoire) {
+  return mongo.db.collection('preleveurs').find(
+    {territoire: codeTerritoire, deletedAt: {$exists: false}}
+  ).toArray()
 }
 
 export async function getPreleveursFromTerritoire(codeTerritoire) {
@@ -40,7 +42,7 @@ export async function getPreleveurByEmail(email) {
   mongo.db.collection('preleveurs').findOne({email, deletedAt: {$exists: false}})
 }
 
-export async function createPreleveur(payload) {
+export async function createPreleveur(payload, codeTerritoire) {
   const preleveur = validateCreation(payload)
 
   if (!preleveur.nom && !preleveur.sigle && !preleveur.raison_sociale) {
@@ -56,6 +58,7 @@ export async function createPreleveur(payload) {
   }
 
   preleveur.id_preleveur = nanoid()
+  preleveur.territoire = codeTerritoire
   preleveur.createdAt = new Date()
   preleveur.updatedAt = new Date()
 
@@ -64,7 +67,7 @@ export async function createPreleveur(payload) {
   return preleveur
 }
 
-export async function updatePreleveur(idPreleveur, payload) {
+export async function updatePreleveur(idPreleveur, codeTerritoire, payload) {
   const changes = validateChanges(payload)
 
   if (Object.keys(changes).length === 0) {
@@ -74,7 +77,7 @@ export async function updatePreleveur(idPreleveur, payload) {
   changes.updatedAt = new Date()
 
   const preleveur = await mongo.db.collection('preleveurs').findOneAndUpdate(
-    {id_preleveur: idPreleveur, deletedAt: {$exists: false}},
+    {id_preleveur: idPreleveur, territoire: codeTerritoire, deletedAt: {$exists: false}},
     {$set: changes},
     {returnDocument: 'after'}
   )
@@ -86,7 +89,7 @@ export async function updatePreleveur(idPreleveur, payload) {
   return preleveur
 }
 
-export async function deletePreleveur(idPreleveur) {
+export async function deletePreleveur(idPreleveur, codeTerritoire) {
   const activeExploitation = await mongo.db.collection('exploitations').findOne(
     {id_preleveur: idPreleveur, statut: 'En activité'}
   )
@@ -96,7 +99,7 @@ export async function deletePreleveur(idPreleveur) {
   }
 
   return mongo.db.collection('preleveurs').findOneAndUpdate(
-    {id_preleveur: idPreleveur, deletedAt: {$exists: false}},
+    {id_preleveur: idPreleveur, territoire: codeTerritoire, deletedAt: {$exists: false}},
     {$set: {
       deletedAt: new Date(),
       updatedAt: new Date()

--- a/lib/models/volume-preleve.js
+++ b/lib/models/volume-preleve.js
@@ -24,9 +24,9 @@ export async function insertVolumesPreleves(exploitationId, volumesPreleves) {
   await mongo.db.collection('volumes_preleves').bulkWrite(operations)
 }
 
-export async function getVolumesPreleves(exploitationId) {
+export async function getVolumesPreleves(exploitationId, codeTerritoire) {
   return mongo.db.collection('volumes_preleves')
-    .find({exploitation: exploitationId})
+    .find({exploitation: exploitationId, territoire: codeTerritoire})
     .project({_id: 0, exploitation: 0})
     .sort({date: -1})
     .toArray()

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,4 +1,3 @@
-import process from 'node:process'
 import {Router} from 'express'
 import createHttpError from 'http-errors'
 import {eachDayOfInterval} from 'date-fns'
@@ -112,13 +111,13 @@ async function createRoutes() {
 
   app.route('/points-prelevement')
     .get(w(ensureIsAdmin), w(async (req, res) => {
-      const prelevements = await getPointsPrelevement()
+      const prelevements = await getPointsPrelevement(req.territoire)
       const decoratedPoints = await Promise.all(prelevements.map(p => decoratePointPrelevement(p)))
 
       res.send(decoratedPoints)
     }))
     .post(w(ensureIsAdmin), w(async (req, res) => {
-      const point = await createPointPrelevement(req.body)
+      const point = await createPointPrelevement(req.body, req.territoire)
       const decoratedPoint = await decoratePointPrelevement(point)
 
       res.send(decoratedPoint)
@@ -126,10 +125,10 @@ async function createRoutes() {
 
   app.route('/points-prelevement/:id')
     .get(w(ensureIsAdmin), w(async (req, res) => {
-      const pointPrelevement = await getPointPrelevement(req.params.id)
+      const pointPrelevement = await getPointPrelevement(req.params.id, req.territoire)
 
       if (!pointPrelevement) {
-        createHttpError(404, 'Ce point de prélèvement est introuvable.')
+        throw createHttpError(404, 'Ce point de prélèvement est introuvable.')
       }
 
       const decoratedPoint = await decoratePointPrelevement(pointPrelevement)
@@ -137,46 +136,50 @@ async function createRoutes() {
       res.send(decoratedPoint)
     }))
     .put(w(ensureIsAdmin), w(async (req, res) => {
-      const point = await updatePointPrelevement(req.params.id, req.body)
+      const point = await updatePointPrelevement(req.params.id, req.territoire, req.body)
 
       res.send(point)
     }))
     .delete(w(ensureIsAdmin), w(async (req, res) => {
-      const deletedPoint = await deletePointPrelevement(req.params.id)
+      const deletedPoint = await deletePointPrelevement(req.params.id, req.territoire)
+
+      if (!deletedPoint) {
+        throw createHttpError(404, 'Ce point de prélèvement est introuvable.')
+      }
 
       res.send(deletedPoint)
     }))
 
   app.get('/points-prelevement/:id/exploitations', w(ensureIsAdmin), w(async (req, res) => {
-    const exploitations = await getExploitationsFromPointId(req.params.id)
+    const exploitations = await getExploitationsFromPointId(req.params.id, req.territoire)
 
     res.send(exploitations)
   }))
 
   app.route('/exploitations')
     .post(w(ensureIsAdmin), w(async (req, res) => {
-      const exploitation = await createExploitation(req.body)
+      const exploitation = await createExploitation(req.body, req.territoire)
 
       res.send(exploitation)
     }))
 
   app.route('/exploitations/:id')
     .get(w(ensureIsAdmin), w(async (req, res) => {
-      const exploitation = await getExploitation(req.params.id)
+      const exploitation = await getExploitation(req.params.id, req.territoire)
 
       if (!exploitation) {
-        createHttpError(404, 'Cette exploitation est introuvable.')
+        throw createHttpError(404, 'Cette exploitation est introuvable.')
       }
 
       res.send(exploitation)
     }))
     .put(w(ensureIsAdmin), w(async (req, res) => {
-      const exploitation = await updateExploitation(req.params.id, req.body)
+      const exploitation = await updateExploitation(req.params.id, req.territoire, req.body)
 
       res.send(exploitation)
     }))
     .delete(w(ensureIsAdmin), w(async (req, res) => {
-      const deletedExploitation = await deleteExploitation(req.params.id)
+      const deletedExploitation = await deleteExploitation(req.params.id, req.territoire)
 
       res.send(deletedExploitation)
     }))
@@ -184,10 +187,12 @@ async function createRoutes() {
   app.get('/exploitations/:id/volumes-preleves', w(ensureIsAdmin), w(async (req, res) => {
     const volumesPreleves = await getVolumesPreleves(req.params.id)
 
-    const exploitation = await mongo.db.collection('exploitations').findOne({id_exploitation: req.params.id})
+    const exploitation = await mongo.db.collection('exploitations').findOne(
+      {id_exploitation: req.params.id, territoire: req.territoire}
+    )
 
     if (!exploitation) {
-      createHttpError(404, 'Cette exploitation est introuvable.')
+      throw createHttpError(404, 'Cette exploitation est introuvable.')
     }
 
     const reglesIds = exploitation.regles || []
@@ -229,23 +234,23 @@ async function createRoutes() {
 
   app.route('/preleveurs')
     .get(w(ensureIsAdmin), w(async (req, res) => {
-      const preleveurs = await getPreleveurs()
+      const preleveurs = await getPreleveurs(req.territoire)
       const decoratedPreleveurs = await Promise.all(preleveurs.map(b => decoratePreleveur(b)))
 
       res.send(decoratedPreleveurs)
     }))
     .post(w(ensureIsAdmin), w(async (req, res) => {
-      const preleveur = await createPreleveur(req.body)
+      const preleveur = await createPreleveur(req.body, req.territoire)
 
       res.send(preleveur)
     }))
 
   app.route('/preleveurs/:id')
     .get(w(ensureIsAdmin), w(async (req, res) => {
-      const preleveur = await getPreleveur(req.params.id)
+      const preleveur = await getPreleveur(req.params.id, req.territoire)
 
       if (!preleveur) {
-        createHttpError(404, 'Ce préleveur est introuvable.')
+        throw createHttpError(404, 'Ce préleveur est introuvable.')
       }
 
       const decoratedPreleveur = await decoratePreleveur(preleveur)
@@ -253,18 +258,18 @@ async function createRoutes() {
       res.send(decoratedPreleveur)
     }))
     .put(w(ensureIsAdmin), w(async (req, res) => {
-      const preleveur = await updatePreleveur(req.params.id, req.body)
+      const preleveur = await updatePreleveur(req.params.id, req.territoire, req.body)
 
       res.send(preleveur)
     }))
     .delete(w(ensureIsAdmin), w(async (req, res) => {
-      const deletedPreleveur = await deletePreleveur(req.params.id)
+      const deletedPreleveur = await deletePreleveur(req.params.id, req.territoire)
 
       res.send(deletedPreleveur)
     }))
 
   app.get('/preleveurs/:id/points-prelevement', w(ensureIsAdmin), w(async (req, res) => {
-    const points = await getPointsFromPreleveur(req.params.id)
+    const points = await getPointsFromPreleveur(req.params.id, req.territoire)
 
     res.send(points)
   }))

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -55,6 +55,12 @@ export const handleDossier = w(async (req, res, next) => {
   next()
 })
 
+async function getTerritoireByToken(token) {
+  const territoire = await mongo.db.collection('tokens').findOne({token})
+
+  return territoire
+}
+
 async function createRoutes() {
   const app = new Router()
 
@@ -65,12 +71,14 @@ async function createRoutes() {
     }
 
     const token = req.get('Authorization').split(' ')[1]
+    const codeTerritoire = await getTerritoireByToken(token)
 
-    if (token !== process.env.TOKEN) {
+    if (!codeTerritoire) {
       return next(createHttpError(401, 'Unauthorized'))
     }
 
     req.isAdmin = true
+    req.territoire = codeTerritoire.territoire
 
     next()
   }))


### PR DESCRIPTION
Ces modifications ajoutent l'authentification par territoire.

Lorsque l'utilisateur fait des appels à l'API, une fonction vérifie à quels territoires le jeton d'authentification permet d'accéder.
Cela permettra de gérer plusieurs territoires sans que les utilisateurs aient à s'en soucier.

- Ajout d'une fonction pour vérifier l'accès aux territoires
- Ajout du code territoire dans les routes et les fonctions CRUD
- Corrections d'erreur non "throw"