### PR TITLE
Correction de la fonction getPreleveurByEmail

### DIFF
--- a/lib/models/preleveur.js
+++ b/lib/models/preleveur.js
@@ -39,7 +39,7 @@ export async function getPreleveursFromTerritoire(codeTerritoire) {
 }
 
 export async function getPreleveurByEmail(email) {
-  mongo.db.collection('preleveurs').findOne({email, deletedAt: {$exists: false}})
+  return mongo.db.collection('preleveurs').findOne({email, deletedAt: {$exists: false}})
 }
 
 export async function createPreleveur(payload, codeTerritoire) {


### PR DESCRIPTION
## Description
La fonction `getPreleveursByEmail` helper ne retourne pas la promise de MongoDB, elle renvoi donc toujours `undefined`.
Cette PR assure que la promise est bien retournée.