### PR TITLE
Suppression de l'obligation d'entrer l'id document dans les règles d'une exploitation

### DIFF
--- a/lib/validation/exploitation-validation.js
+++ b/lib/validation/exploitation-validation.js
@@ -110,8 +110,7 @@ const regleSchema = Joi.object().keys({
   debut_periode: Joi.custom(validateDate).allow(null),
   fin_periode: Joi.custom(validateDate).allow(null),
   remarque: addStringMessages(Joi.string().trim().min(3).max(500).allow(null), 'remarque'),
-  id_document: Joi.string().trim().max(200).required().messages({
-    'any.required': 'L’id du document est obligatoire.',
+  id_document: Joi.string().trim().max(200).messages({
     'string.base': 'L’id du document doit être une chaine de caractères.'
   })
 })


### PR DESCRIPTION
Cette PR modifie la définition des règles d'une exploitation : 
Pour la création d'une exploitation, la gestion des documents se fera sur les préleveurs.
Or, l'`id_document` est un champ requis pour l'ajout d'une règle dans une exploitation.

Cette suppression permet de créer une exploitation avec des règles sans renseigner ce champ.

