### PR TITLE
Correction du traitement des fichiers DS

### DIFF
--- a/lib/demarches-simplifiees/index.js
+++ b/lib/demarches-simplifiees/index.js
@@ -5,6 +5,7 @@ import {
   validateCamionCiterneFile,
   validateMultiParamFile
 } from '@fabrique/timeseries-parsers'
+import {calculateObjectSize} from 'bson'
 
 import {defer} from '../util/defer.js'
 import s3 from '../util/s3.js'
@@ -149,6 +150,14 @@ async function processAttachment(attachment, typePrelevement) {
     result.errors.push({
       message: 'Le fichier contient plus de 50 erreurs. Les erreurs suivantes n’ont pas été affichées.'
     })
+  }
+
+  if (calculateObjectSize(result) > 14 * 1024 * 1024) { // 14 Mo
+    await Dossier.updateAttachment(attachment._id, {
+      processingError: 'Attachment result too large',
+      processed: true
+    })
+    return
   }
 
   await Dossier.updateAttachment(attachment._id, {processed: true, result})

--- a/lib/demarches-simplifiees/index.js
+++ b/lib/demarches-simplifiees/index.js
@@ -145,7 +145,7 @@ async function processAttachment(attachment, typePrelevement) {
   }))
 
   if (result.errors?.length > 50) {
-    result.errors = attachment.errors.slice(0, 50)
+    result.errors = result.errors.slice(0, 50)
     result.errors.push({
       message: 'Le fichier contient plus de 50 erreurs. Les erreurs suivantes n’ont pas été affichées.'
     })


### PR DESCRIPTION
## Description
Certains `result` produit par le traitement d'un fichier issue de Démarches Simplifiées sont trop lourd pour être enregistré en base de donnée. Leur traitement provoque l'erreur suivante:
```
RangeError [ERR_OUT_OF_RANGE]: The value of "offset" is out of range. It must be >= 0 && <= 17825792. Received 17825794
```

Cette PR les détectes et enregistre le résultat comme une erreur de traitement : `processingError: 'Attachment result too large'`

### Autre changement
Lorsque que `result.errors` dépasse les 50 éléments, seuls les 50 premiers sont gardés et l'erreur `Le fichier contient plus de 50 erreurs. Les erreurs suivantes n’ont pas été affichées.` est ajoutée. Cependant le `slice` se faisait sur `attachment` et non `result.error` comme il le faudrait. 