### PR TITLE
Ajout d'imports dotenv/config manquants

### DIFF
--- a/scripts/import-territoire-data.js
+++ b/scripts/import-territoire-data.js
@@ -1,6 +1,6 @@
 /* eslint-disable n/prefer-global/process */
 /* eslint-disable unicorn/no-process-exit */
-
+import 'dotenv/config'
 import {argv} from 'node:process'
 import mongo from '../lib/util/mongo.js'
 import {readDataFromCsvFile} from '../lib/import/csv.js'

--- a/scripts/referentiel-import.js
+++ b/scripts/referentiel-import.js
@@ -1,6 +1,6 @@
 /* eslint-disable n/prefer-global/process */
 /* eslint-disable unicorn/no-process-exit */
-
+import 'dotenv/config'
 import {argv} from 'node:process'
 import {keyBy} from 'lodash-es'
 import mongo from '../lib/util/mongo.js'


### PR DESCRIPTION
## Description
L'import de `dotenv/config` est manquant dans les scripts `import-territoire-data.js` et `referentiel-import.js` empêchant, entre autre, le bon chargement des variables d'environnement `MONGODB_DBNAME` et `MONGODB_URL`.