### PR TITLE
Correction du nom du package @fabnum/prelevements-deau-timeseries-parsers

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -5,7 +5,7 @@ Ce dépôt fournit deux fonctions principales pour valider les fichiers provenan
 - `validateCamionCiterneFile`
 - `validateMultiParamFile`
 
-Ces fonctions sont exposées par le package `@fabnum/timeseries-parsers`. Elles renvoient une liste d'objets contenant au moins la propriété `message` (et éventuellement `explanation`, `internalMessage` et `severity`). La sévérité est `error` par défaut et vaut `warning` lorsque le problème n'empêche pas l'import.
+Ces fonctions sont exposées par le package `@fabnum/prelevements-deau-timeseries-parsers`. Elles renvoient une liste d'objets contenant au moins la propriété `message` (et éventuellement `explanation`, `internalMessage` et `severity`). La sévérité est `error` par défaut et vaut `warning` lorsque le problème n'empêche pas l'import.
 
 ## Fonction `validateCamionCiterneFile`
 

--- a/lib/demarches-simplifiees/index.js
+++ b/lib/demarches-simplifiees/index.js
@@ -4,7 +4,7 @@ import 'dotenv/config'
 import {
   validateCamionCiterneFile,
   validateMultiParamFile
-} from '@fabnum/timeseries-parsers'
+} from '@fabnum/prelevements-deau-timeseries-parsers'
 import {calculateObjectSize} from 'bson'
 
 import {defer} from '../util/defer.js'

--- a/scripts/read-multi-params.js
+++ b/scripts/read-multi-params.js
@@ -3,7 +3,7 @@ import process from 'node:process'
 import path from 'node:path'
 import {readFile} from 'node:fs/promises'
 
-import {validateMultiParamFile} from '@fabnum/timeseries-parsers'
+import {validateMultiParamFile} from '@fabnum/prelevements-deau-timeseries-parsers'
 
 const filePath = process.argv[2]
 


### PR DESCRIPTION
## Description
Le nom du package `@fabnum/prelevements-deau-timeseries-parsers` n'a pas correctement été mis à jour partout. Cette PR corrige ces imports et met à jour son nom dans la documentation.