### PR TITLE
Traduction des messages de validation des préleveurs

### DIFF
--- a/lib/validation/preleveur-validation.js
+++ b/lib/validation/preleveur-validation.js
@@ -4,7 +4,11 @@ import {validatePayload} from '../util/payload.js'
 function addStringMessages(field, fieldName) {
   return field.messages({
     'string.base': `Le champ "${fieldName}" doit être une chaine de caractères.`,
-    'string.empty': `Le champ "${fieldName}" ne peut pas être vide.`
+    'string.empty': `Le champ "${fieldName}" ne peut pas être vide.`,
+    'string.min': `Le champ "${fieldName}" doit comporter au moins {#limit} caractères.`,
+    'string.max': `Le champ "${fieldName}" ne doit pas comporter plus de {#limit} caractères.`,
+    'string.email': `Le champ "${fieldName}" doit être une adresse email valide.`,
+    'any.only': `Les valeurs valides pour le champ "${fieldName}" sont {#valids}.`
   })
 }
 
@@ -25,19 +29,19 @@ const PRELEVEUR_FIELDS = {
 }
 
 const preleveurSchema = Joi.object().keys({
-  raison_sociale: PRELEVEUR_FIELDS.raison_sociale.allow(null),
-  sigle: PRELEVEUR_FIELDS.sigle.allow(null),
-  civilite: addStringMessages(PRELEVEUR_FIELDS.civilite.allow(null), 'civilite'),
-  nom: PRELEVEUR_FIELDS.nom.allow(null),
-  prenom: addStringMessages(PRELEVEUR_FIELDS.prenom.allow(null), 'prenom'),
-  email: addStringMessages(PRELEVEUR_FIELDS.email.allow(null), 'email'),
-  adresse_1: addStringMessages(PRELEVEUR_FIELDS.adresse_1.allow(null), 'adresse_1'),
-  adresse_2: addStringMessages(PRELEVEUR_FIELDS.adresse_2.allow(null), 'adresse_2'),
-  bp: addStringMessages(PRELEVEUR_FIELDS.bp.allow(null), 'bp'),
-  code_postal: addStringMessages(PRELEVEUR_FIELDS.code_postal.allow(null), 'code_postal'),
-  commune: addStringMessages(PRELEVEUR_FIELDS.commune.allow(null), 'commune'),
-  numero_telephone: addStringMessages(PRELEVEUR_FIELDS.numero_telephone.allow(null), 'numero_telephone'),
-  code_siren: addStringMessages(PRELEVEUR_FIELDS.code_siren.allow(null), 'code_siren')
+  raison_sociale: addStringMessages(PRELEVEUR_FIELDS.raison_sociale.allow(null), 'Raison sociale'),
+  sigle: addStringMessages(PRELEVEUR_FIELDS.sigle.allow(null), 'Sigle'),
+  civilite: addStringMessages(PRELEVEUR_FIELDS.civilite.allow(null), 'Civilite'),
+  nom: addStringMessages(PRELEVEUR_FIELDS.nom.allow(null), 'Nom'),
+  prenom: addStringMessages(PRELEVEUR_FIELDS.prenom.allow(null), 'Prenom'),
+  email: addStringMessages(PRELEVEUR_FIELDS.email.allow(null), 'Email'),
+  adresse_1: addStringMessages(PRELEVEUR_FIELDS.adresse_1.allow(null), 'Adresse ligne 1'),
+  adresse_2: addStringMessages(PRELEVEUR_FIELDS.adresse_2.allow(null), 'Adresse ligne 2'),
+  bp: addStringMessages(PRELEVEUR_FIELDS.bp.allow(null), 'Boite postale'),
+  code_postal: addStringMessages(PRELEVEUR_FIELDS.code_postal.allow(null), 'Code postal'),
+  commune: addStringMessages(PRELEVEUR_FIELDS.commune.allow(null), 'Commune'),
+  numero_telephone: addStringMessages(PRELEVEUR_FIELDS.numero_telephone.allow(null), 'Numéro de téléphone'),
+  code_siren: addStringMessages(PRELEVEUR_FIELDS.code_siren.allow(null), 'Code siren')
 }).messages({
   'object.unknown': 'Une clé de l’objet est invalide.'
 })


### PR DESCRIPTION
Cette PR traduit en français les messages de validation lors de la création ou l'édition d'un préleveur.
J'ai également modifié les noms des champs renvoyés dans les messages de validation.