### PR TITLE
Correction de l'extraction des données journalière

### DIFF
--- a/packages/timeseries-parsers/lib/camion-citerne/index.js
+++ b/packages/timeseries-parsers/lib/camion-citerne/index.js
@@ -306,8 +306,8 @@ function consolidateData(rawData) {
   const data = rawData.headers.map((header, i) => {
     const dailyValues = rawData.dailyValues.map(row => ({
       date: row.date,
-      value: row.values[i]
-    })).filter(v => v.value)
+      values: row.values[i] ? [row.values[i]] : null
+    })).filter(v => v.values)
 
     if (dailyValues.length === 0) {
       return
@@ -325,7 +325,7 @@ function consolidateData(rawData) {
         unite: 'm3'
       }],
       dailyValues,
-      volumePreleveTotal: sumBy(dailyValues, 'value')
+      volumePreleveTotal: sumBy(dailyValues, row => row.values[0])
     }
   })
 

--- a/packages/timeseries-parsers/package.json
+++ b/packages/timeseries-parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fabnum/prelevements-deau-timeseries-parsers",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Description
L'extraction des données journalière a été corrigé dans la validation des fichiers de prélèvements par camion citerne. Le package `@fabnum/prelevements-deau-timeseries-parsers` est passé en version `0.0.6`