### PR TITLE
Ajout d'un statut de validation aux fichiers des dossiers DS

### DIFF
--- a/lib/demarches-simplifiees/index.js
+++ b/lib/demarches-simplifiees/index.js
@@ -131,9 +131,8 @@ async function processAttachment(attachment, typePrelevement) {
   let validationStatus = null
 
   if (typePrelevement === 'camion-citerne') {
-    const {errors, data} = await validateCamionCiterneFile(buffer)
+    const {errors} = await validateCamionCiterneFile(buffer)
     result.errors = errors
-    result.data = data
   } else if (typePrelevement === 'aep-zre') {
     const {errors, data} = await validateMultiParamFile(buffer)
     result.errors = errors

--- a/lib/demarches-simplifiees/index.js
+++ b/lib/demarches-simplifiees/index.js
@@ -75,9 +75,7 @@ async function consolidateDossier(demarcheNumber, dossierNumber) {
   console.log(`Consolidating dossier ${demarcheNumber}/${dossierNumber}`)
   const dossier = await Dossier.getDossierByNumero(demarcheNumber, dossierNumber)
 
-  if (dossier.attachmentsUpdated) {
-    await processAttachments(demarcheNumber, dossierNumber, dossier.typePrelevement)
-  }
+  await processAttachments(demarcheNumber, dossierNumber, dossier.typePrelevement)
 
   const result = {}
 
@@ -133,8 +131,9 @@ async function processAttachment(attachment, typePrelevement) {
   let validationStatus = null
 
   if (typePrelevement === 'camion-citerne') {
-    const {errors} = await validateCamionCiterneFile(buffer)
+    const {errors, data} = await validateCamionCiterneFile(buffer)
     result.errors = errors
+    result.data = data
   } else if (typePrelevement === 'aep-zre') {
     const {errors, data} = await validateMultiParamFile(buffer)
     result.errors = errors

--- a/lib/demarches-simplifiees/index.js
+++ b/lib/demarches-simplifiees/index.js
@@ -130,6 +130,7 @@ async function processAttachment(attachment, typePrelevement) {
   }
 
   const result = {}
+  let validationStatus = null
 
   if (typePrelevement === 'camion-citerne') {
     const {errors} = await validateCamionCiterneFile(buffer)
@@ -155,12 +156,21 @@ async function processAttachment(attachment, typePrelevement) {
   if (calculateObjectSize(result) > 14 * 1024 * 1024) { // 14 Mo
     await Dossier.updateAttachment(attachment._id, {
       processingError: 'Attachment result too large',
-      processed: true
+      processed: true,
+      validationStatus: 'failed'
     })
     return
   }
 
-  await Dossier.updateAttachment(attachment._id, {processed: true, result})
+  if (result && result.errors?.length > 0) {
+    validationStatus = result.errors.some(error => error.severity === 'error')
+      ? 'error'
+      : 'warning'
+  } else {
+    validationStatus = 'success'
+  }
+
+  await Dossier.updateAttachment(attachment._id, {processed: true, result, validationStatus})
 }
 
 /* Helpers */

--- a/lib/models/dossier.js
+++ b/lib/models/dossier.js
@@ -89,3 +89,29 @@ export async function getAttachmentByStorageHash(demarcheNumber, dossierNumber, 
     return getAttachmentByStorageKey(demarcheNumber, dossierNumber, storageKey, withDataAndErrors)
   }
 }
+
+export async function decorateDossier(dossier) {
+  const attachments = await mongo.db.collection('dossier_attachments')
+    .find({demarcheNumber: dossier.demarcheNumber, dossierNumber: dossier.number})
+    .project({_id: 0, validationStatus: 1})
+    .toArray()
+
+  let validationStatus
+  if (!attachments || attachments.length === 0) {
+    validationStatus = null
+  }
+
+  const statuses = new Set(attachments.map(a => a.validationStatus))
+  const statusOrder = [null, 'failed', 'error', 'warning', 'success']
+
+  for (const status of statusOrder) {
+    if (statuses.has(status)) {
+      validationStatus = status
+    }
+  }
+
+  return {
+    ...dossier,
+    validationStatus
+  }
+}

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -169,7 +169,8 @@ async function createRoutes() {
 
   app.get('/dossiers', w(async (req, res) => {
     const dossiers = await Dossier.getDossiers(demarcheNumber)
-    res.send(dossiers)
+    const decorateDossiers = await Promise.all(dossiers.map(d => Dossier.decorateDossier(d)))
+    res.send(decorateDossiers)
   }))
 
   app.get('/dossiers/:dossierId', w(async (req, res) => {


### PR DESCRIPTION
## Description
Cette PR ajout un statut de validation aux fichiers des dossiers DS calculé en fonction des erreurs et avertissements produit par leur validation.
Ce statut permettra au front de mettre en avant les dossiers pouvant être validé rapidement dont ce qui demanderont plus d'attention.

### Les statuts:
- `success` : Le fichier ne présente aucune erreur ou avertissement
- `warning` : Le fichier présente au moins un avertissement
- `error` : Le  fichier présente au moins une erreur
- `failed` : La validation du fichier a échoué (erreur interne)
- `null` : Le ficher n'a pas encore passé le processus de validation

### Décorateur
Le décorateur `decorateDossier` permet de récupérer le statut le plus critique des fichiers lié à un dossier afin de pouvoir être affiché dans la listes des dossiers de l'instructeur.

### Autre modification
La condition `dossier.attachmentsUpdated === true` lors de la synchronisation des dossiers a été retiré afin de permettre la re-validation d'un fichier en passant manuellement le champ `processed` à `false`.