### PR TITLE
Correction des statistiques

### DIFF
--- a/lib/models/stats.js
+++ b/lib/models/stats.js
@@ -53,7 +53,7 @@ export async function getStats(territoire) {
       {$project: {
         annee: {$substrBytes: ['$documents.date_signature', 0, 4]},
         nature: '$documents.nature',
-        id: '$documents.id_document'
+        id: '$documents._id'
       }},
       {$group: {
         _id: '$id',


### PR DESCRIPTION
Après la modification récente sur l'importation des documents, la page statistique étant basée sur `id_document` et pas `_id`, un des champs des statistiques était vide.

Cette PR utilise `_id` pour récupérer les documents dans la fonction `getStats` 